### PR TITLE
refactor(cocache): split api and core modules

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -31,7 +31,23 @@ jobs:
 
       - name: Test CoCache-Core
         run: ./gradlew cocache-core:clean cocache-core:check
+  cocache-spring-test:
+    name: CoCache Spring Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
 
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: github
+          settings-path: ${{ github.workspace }}
+
+      - name: Test CoCache-Spring
+        run: ./gradlew cocache-spring:clean cocache-spring:check
   cocache-spring-redis-test:
     name: CoCache Spring Redis Test
     needs: [ cocache-core-test ]

--- a/cocache-api/src/main/kotlin/me/ahoo/cache/api/Cache.kt
+++ b/cocache-api/src/main/kotlin/me/ahoo/cache/api/Cache.kt
@@ -10,19 +10,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package me.ahoo.cache.spring.redis.codec
 
-import me.ahoo.cache.api.CacheValue
+package me.ahoo.cache.api
 
 /**
- * Codec Executor .
+ * Cache api.
  *
  * @author ahoo wang
  */
-interface CodecExecutor<V> {
+interface Cache<K, V> : CacheGetter<K, V> {
+
+    fun getCache(key: K): CacheValue<V>?
+
     /**
-     * @param ttlAt time to live([java.time.temporal.ChronoUnit.SECONDS]).
+     * get cache expire at time.
+     *
+     * @param key cache key
+     * @return when return null:cache not exist.
      */
-    fun executeAndDecode(key: String, ttlAt: Long): CacheValue<V>
-    fun executeAndEncode(key: String, cacheValue: CacheValue<V>)
+    fun getTtlAt(key: K): Long?
+
+    operator fun set(key: K, ttlAt: Long, value: V)
+
+    operator fun set(key: K, value: V)
+
+    fun setCache(key: K, value: CacheValue<V>)
+
+    /**
+     * evict cache.
+     *
+     * @param key cache key
+     */
+    fun evict(key: K)
 }

--- a/cocache-api/src/main/kotlin/me/ahoo/cache/api/CacheGetter.kt
+++ b/cocache-api/src/main/kotlin/me/ahoo/cache/api/CacheGetter.kt
@@ -10,19 +10,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package me.ahoo.cache.spring.redis.codec
-
-import me.ahoo.cache.api.CacheValue
+package me.ahoo.cache.api
 
 /**
- * Codec Executor .
+ * Cache Getter .
  *
  * @author ahoo wang
  */
-interface CodecExecutor<V> {
+interface CacheGetter<K, V> {
     /**
-     * @param ttlAt time to live([java.time.temporal.ChronoUnit.SECONDS]).
+     * Get the real cache value.
+     *
+     * @param key cache key
+     * @return real cache value
      */
-    fun executeAndDecode(key: String, ttlAt: Long): CacheValue<V>
-    fun executeAndEncode(key: String, cacheValue: CacheValue<V>)
+    operator fun get(key: K): V?
 }

--- a/cocache-api/src/main/kotlin/me/ahoo/cache/api/CacheValue.kt
+++ b/cocache-api/src/main/kotlin/me/ahoo/cache/api/CacheValue.kt
@@ -10,19 +10,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package me.ahoo.cache.source
-
-import me.ahoo.cache.CacheSource
-import me.ahoo.cache.CacheValue
+package me.ahoo.cache.api
 
 /**
- * No Op Cache Source .
+ * Cache Value .
  *
  * @author ahoo wang
  */
-object NoOpCacheSource : CacheSource<Any, Any> {
+interface CacheValue<V> : TtlAt {
+    val value: V
 
-    override fun load(key: Any): CacheValue<Any>? {
-        return null
-    }
+    /**
+     * get time to live([java.time.temporal.ChronoUnit.SECONDS]).
+     *
+     * @return time to live (second)
+     */
+    override val ttlAt: Long
+
+    val isMissingGuard: Boolean
 }

--- a/cocache-api/src/main/kotlin/me/ahoo/cache/api/NamedCache.kt
+++ b/cocache-api/src/main/kotlin/me/ahoo/cache/api/NamedCache.kt
@@ -10,13 +10,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package me.ahoo.cache
+package me.ahoo.cache.api
 
 /**
- * Cache Getter .
+ * Named Caching .
  *
  * @author ahoo wang
  */
-interface CacheGetter<K, V> {
-    operator fun get(key: K): V?
+interface NamedCache {
+    /**
+     * Return the cache name.
+     *
+     * @return cache name
+     */
+    val cacheName: String
 }

--- a/cocache-api/src/main/kotlin/me/ahoo/cache/api/TtlAt.kt
+++ b/cocache-api/src/main/kotlin/me/ahoo/cache/api/TtlAt.kt
@@ -10,18 +10,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package me.ahoo.cache
+package me.ahoo.cache.api
+
+import java.time.Duration
 
 /**
- * Named Caching .
+ * TtlAt .
  *
  * @author ahoo wang
  */
-interface NamedCache {
+interface TtlAt {
     /**
-     * Return the cache name.
+     * get time to live([java.time.temporal.ChronoUnit.SECONDS]).
      *
-     * @return cache name
+     * @return time to live
      */
-    val cacheName: String
+    val ttlAt: Long
+    val isForever: Boolean
+    val isExpired: Boolean
+    val expiredDuration: Duration
 }

--- a/cocache-api/src/main/kotlin/me/ahoo/cache/api/source/CacheSource.kt
+++ b/cocache-api/src/main/kotlin/me/ahoo/cache/api/source/CacheSource.kt
@@ -10,19 +10,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package me.ahoo.cache.spring.redis.codec
+package me.ahoo.cache.api.source
 
 import me.ahoo.cache.api.CacheValue
 
 /**
- * Codec Executor .
+ * L0
+ * Cache Source .
  *
  * @author ahoo wang
  */
-interface CodecExecutor<V> {
-    /**
-     * @param ttlAt time to live([java.time.temporal.ChronoUnit.SECONDS]).
-     */
-    fun executeAndDecode(key: String, ttlAt: Long): CacheValue<V>
-    fun executeAndEncode(key: String, cacheValue: CacheValue<V>)
+interface CacheSource<K, V> {
+    fun load(key: K): CacheValue<V>?
+
+    companion object {
+        @JvmStatic
+        fun <K, V> noOp(): CacheSource<K, V> {
+            @Suppress("UNCHECKED_CAST")
+            return NoOpCacheSource as CacheSource<K, V>
+        }
+    }
 }

--- a/cocache-api/src/main/kotlin/me/ahoo/cache/api/source/NoOpCacheSource.kt
+++ b/cocache-api/src/main/kotlin/me/ahoo/cache/api/source/NoOpCacheSource.kt
@@ -10,24 +10,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package me.ahoo.cache
+package me.ahoo.cache.api.source
 
-import me.ahoo.cache.source.NoOpCacheSource
+import me.ahoo.cache.api.CacheValue
 
 /**
- * L0
- * Cache Source .
+ * No Op Cache Source .
  *
  * @author ahoo wang
  */
-interface CacheSource<K, V> {
-    fun load(key: K): CacheValue<V>?
+object NoOpCacheSource : CacheSource<Any, Any> {
 
-    companion object {
-        @JvmStatic
-        fun <K, V> noOp(): CacheSource<K, V> {
-            @Suppress("UNCHECKED_CAST")
-            return NoOpCacheSource as CacheSource<K, V>
-        }
+    override fun load(key: Any): CacheValue<Any>? {
+        return null
     }
 }

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/CacheManager.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/CacheManager.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.cache
 
+import me.ahoo.cache.api.source.CacheSource
 import me.ahoo.cache.client.ClientSideCache
 import me.ahoo.cache.client.MapClientSideCache
 import me.ahoo.cache.consistency.CacheEvictedEventBus

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/ComputedCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/ComputedCache.kt
@@ -13,16 +13,12 @@
 
 package me.ahoo.cache
 
-import me.ahoo.cache.CacheValue.Companion.forever
-import me.ahoo.cache.CacheValue.Companion.missingGuard
-import me.ahoo.cache.CacheValue.Companion.missingGuardValue
+import me.ahoo.cache.DefaultCacheValue.Companion.forever
+import me.ahoo.cache.DefaultCacheValue.Companion.missingGuard
+import me.ahoo.cache.DefaultCacheValue.Companion.missingGuardValue
+import me.ahoo.cache.api.Cache
 
-/**
- * Cache api.
- *
- * @author ahoo wang
- */
-interface Cache<K, V> : CacheGetter<K, V> {
+interface ComputedCache<K, V> : Cache<K, V> {
     /**
      * Get the real cache value.
      *
@@ -38,8 +34,6 @@ interface Cache<K, V> : CacheGetter<K, V> {
         return cacheValue.value
     }
 
-    fun getCache(key: K): CacheValue<V>?
-
     /**
      * get cache expire at time.
      *
@@ -47,7 +41,7 @@ interface Cache<K, V> : CacheGetter<K, V> {
      * @return when return null:cache not exist.
      */
     @Suppress("ReturnCount")
-    fun getTtlAt(key: K): Long? {
+    override fun getTtlAt(key: K): Long? {
         val cacheValue = getCache(key) ?: return null
         if (cacheValue.isMissingGuard) {
             return null
@@ -55,21 +49,12 @@ interface Cache<K, V> : CacheGetter<K, V> {
         return cacheValue.ttlAt
     }
 
-    operator fun set(key: K, ttlAt: Long, value: V) {
-        setCache(key, CacheValue(value, ttlAt))
+    override operator fun set(key: K, ttlAt: Long, value: V) {
+        setCache(key, DefaultCacheValue(value, ttlAt))
     }
 
-    operator fun set(key: K, value: V) {
+    override operator fun set(key: K, value: V) {
         val cacheValue = if (missingGuardValue<Any>() == value) missingGuard() else forever(value)
         setCache(key, cacheValue)
     }
-
-    fun setCache(key: K, value: CacheValue<V>)
-
-    /**
-     * evict cache.
-     *
-     * @param key cache key
-     */
-    fun evict(key: K)
 }

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/ComputedTtlAt.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/ComputedTtlAt.kt
@@ -10,33 +10,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package me.ahoo.cache
 
+import me.ahoo.cache.api.TtlAt
 import me.ahoo.cache.util.CacheSecondClock
 import java.time.Duration
 
-/**
- * TtlAt .
- *
- * @author ahoo wang
- */
-interface TtlAt {
-    /**
-     * get time to live([java.time.temporal.ChronoUnit.SECONDS]).
-     *
-     * @return time to live
-     */
-    val ttlAt: Long
-    val isForever: Boolean
+interface ComputedTtlAt : TtlAt {
+
+    override val isForever: Boolean
         get() = isForever(ttlAt)
-    val isExpired: Boolean
+    override val isExpired: Boolean
         get() = if (isForever) {
             false
         } else {
             CacheSecondClock.INSTANCE.currentTime() > ttlAt
         }
 
-    val expiredDuration: Duration
+    override val expiredDuration: Duration
         get() {
             val currentTime = CacheSecondClock.INSTANCE.currentTime()
             return if (currentTime > ttlAt) {

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/CoCacheMetadata.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/CoCacheMetadata.kt
@@ -13,7 +13,7 @@
 
 package me.ahoo.cache.annotation
 
-import me.ahoo.cache.NamedCache
+import me.ahoo.cache.api.NamedCache
 import kotlin.reflect.KClass
 
 data class CoCacheMetadata(

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParser.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParser.kt
@@ -13,7 +13,8 @@
 
 package me.ahoo.cache.annotation
 
-import me.ahoo.cache.Cache
+import me.ahoo.cache.ComputedCache
+import me.ahoo.cache.api.Cache
 import me.ahoo.cache.api.annotation.CoCache
 import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotation
@@ -39,7 +40,7 @@ object CoCacheMetadataParser {
 
         // 获取继承的 Cache<K,V> 中 V 的具体类型
         val superCacheType = cacheType.supertypes.first {
-            it.classifier == Cache::class
+            it.classifier == Cache::class || it.classifier == ComputedCache::class
         }
         val valueType = superCacheType.arguments.last().type?.classifier as? KClass<*>
         requireNotNull(valueType)

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/ClientSideCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/ClientSideCache.kt
@@ -12,14 +12,14 @@
  */
 package me.ahoo.cache.client
 
-import me.ahoo.cache.Cache
+import me.ahoo.cache.ComputedCache
 
 /**
  * Client Side Cache .
  *
  * @author ahoo wang
  */
-interface ClientSideCache<V> : Cache<String, V> {
+interface ClientSideCache<V> : ComputedCache<String, V> {
     override fun get(key: String): V? {
         val cacheValue = getCache(key) ?: return null
         if (cacheValue.isExpired) {

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/GuavaClientSideCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/GuavaClientSideCache.kt
@@ -14,7 +14,7 @@ package me.ahoo.cache.client
 
 import com.google.common.cache.Cache
 import com.google.common.cache.CacheBuilder
-import me.ahoo.cache.CacheValue
+import me.ahoo.cache.api.CacheValue
 
 /**
  * Guava Client Side Cache .

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/MapClientSideCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/MapClientSideCache.kt
@@ -12,7 +12,7 @@
  */
 package me.ahoo.cache.client
 
-import me.ahoo.cache.CacheValue
+import me.ahoo.cache.api.CacheValue
 import java.util.concurrent.ConcurrentHashMap
 
 /**

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/CacheEvictedEvent.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/CacheEvictedEvent.kt
@@ -12,7 +12,7 @@
  */
 package me.ahoo.cache.consistency
 
-import me.ahoo.cache.NamedCache
+import me.ahoo.cache.api.NamedCache
 
 /**
  * Cache evicted event.

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/CacheEvictedSubscriber.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/CacheEvictedSubscriber.kt
@@ -12,7 +12,7 @@
  */
 package me.ahoo.cache.consistency
 
-import me.ahoo.cache.NamedCache
+import me.ahoo.cache.api.NamedCache
 
 /**
  * Cache Evicted Subscriber .

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/distributed/DistributedCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/distributed/DistributedCache.kt
@@ -12,11 +12,11 @@
  */
 package me.ahoo.cache.distributed
 
-import me.ahoo.cache.Cache
+import me.ahoo.cache.ComputedCache
 
 /**
  * Distributed Caching .
  *
  * @author ahoo wang
  */
-interface DistributedCache<V> : Cache<String, V>, AutoCloseable
+interface DistributedCache<V> : ComputedCache<String, V>, AutoCloseable

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/distributed/mock/MockDistributedCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/distributed/mock/MockDistributedCache.kt
@@ -12,7 +12,7 @@
  */
 package me.ahoo.cache.distributed.mock
 
-import me.ahoo.cache.CacheValue
+import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.distributed.DistributedCache
 import java.util.concurrent.ConcurrentHashMap
 

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/join/JoinCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/join/JoinCache.kt
@@ -1,6 +1,6 @@
 package me.ahoo.cache.join
 
-import me.ahoo.cache.CacheGetter
+import me.ahoo.cache.api.CacheGetter
 
 /**
  * Join Caching.

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/join/SimpleJoinCaching.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/join/SimpleJoinCaching.kt
@@ -12,7 +12,7 @@
  */
 package me.ahoo.cache.join
 
-import me.ahoo.cache.CacheGetter
+import me.ahoo.cache.api.CacheGetter
 
 /**
  * Simple Join Caching .

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/CacheProxyFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/CacheProxyFactory.kt
@@ -13,8 +13,8 @@
 
 package me.ahoo.cache.proxy
 
-import me.ahoo.cache.Cache
 import me.ahoo.cache.annotation.CoCacheMetadata
+import me.ahoo.cache.api.Cache
 
 @FunctionalInterface
 interface CacheProxyFactory {

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/CacheSourceResolver.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/CacheSourceResolver.kt
@@ -13,8 +13,8 @@
 
 package me.ahoo.cache.proxy
 
-import me.ahoo.cache.CacheSource
 import me.ahoo.cache.annotation.CoCacheMetadata
+import me.ahoo.cache.api.source.CacheSource
 
 @FunctionalInterface
 interface CacheSourceResolver {

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/CoCacheInvocationHandler.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/CoCacheInvocationHandler.kt
@@ -13,8 +13,8 @@
 
 package me.ahoo.cache.proxy
 
-import me.ahoo.cache.Cache
-import me.ahoo.cache.NamedCache
+import me.ahoo.cache.api.Cache
+import me.ahoo.cache.api.NamedCache
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactory.kt
@@ -13,11 +13,11 @@
 
 package me.ahoo.cache.proxy
 
-import me.ahoo.cache.Cache
 import me.ahoo.cache.CacheConfig
 import me.ahoo.cache.CacheManager
-import me.ahoo.cache.NamedCache
 import me.ahoo.cache.annotation.CoCacheMetadata
+import me.ahoo.cache.api.Cache
+import me.ahoo.cache.api.NamedCache
 import me.ahoo.cache.api.annotation.CoCache
 import me.ahoo.cache.converter.ToStringKeyConverter
 import me.ahoo.cache.distributed.DistributedCache

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/TtlTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/TtlTest.kt
@@ -21,32 +21,32 @@ import org.junit.jupiter.api.Test
 class TtlTest {
     @Test
     fun isForever() {
-        val ttlAt = TtlAt.FOREVER
-        assertThat(TtlAt.isForever(ttlAt), equalTo(true))
+        val ttlAt = ComputedTtlAt.FOREVER
+        assertThat(ComputedTtlAt.isForever(ttlAt), equalTo(true))
     }
 
     @Test
     fun at() {
-        val ttlAt = TtlAt.at(10)
+        val ttlAt = ComputedTtlAt.at(10)
         assertThat(ttlAt, greaterThan(CacheSecondClock.INSTANCE.currentTime()))
     }
 
     @Test
     fun atWithAmplitude() {
-        val ttlAt = TtlAt.at(10, 5)
+        val ttlAt = ComputedTtlAt.at(10, 5)
         assertThat(ttlAt, greaterThanOrEqualTo(CacheSecondClock.INSTANCE.currentTime() + 5))
         assertThat(ttlAt, lessThanOrEqualTo(CacheSecondClock.INSTANCE.currentTime() + 15))
     }
 
     @Test
     fun jitterZero() {
-        val jitterTtlAt = TtlAt.jitter(60, 0)
+        val jitterTtlAt = ComputedTtlAt.jitter(60, 0)
         assertThat(jitterTtlAt, equalTo(60))
     }
 
     @Test
     fun jitter() {
-        val jitterTtlAt = TtlAt.jitter(60, 10)
+        val jitterTtlAt = ComputedTtlAt.jitter(60, 10)
         assertThat(jitterTtlAt, greaterThanOrEqualTo(50))
         assertThat(jitterTtlAt, lessThanOrEqualTo(70))
     }

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParserTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParserTest.kt
@@ -1,6 +1,7 @@
 package me.ahoo.cache.annotation
 
-import me.ahoo.cache.Cache
+import me.ahoo.cache.ComputedCache
+import me.ahoo.cache.api.Cache
 import me.ahoo.cache.api.annotation.CoCache
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -46,5 +47,5 @@ class CoCacheMetadataParserTest {
 
     interface NotSubclassOfCache
 
-    interface NotCacheAnnotation : Cache<String, CoCacheMetadataParserTest>
+    interface NotCacheAnnotation : ComputedCache<String, CoCacheMetadataParserTest>
 }

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/join/SimpleJoinCachingTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/join/SimpleJoinCachingTest.kt
@@ -12,7 +12,7 @@
  */
 package me.ahoo.cache.join
 
-import me.ahoo.cache.CacheValue.Companion.forever
+import me.ahoo.cache.DefaultCacheValue.Companion.forever
 import me.ahoo.cache.client.MapClientSideCache
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactoryTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactoryTest.kt
@@ -1,10 +1,10 @@
 package me.ahoo.cache.proxy
 
 import me.ahoo.cache.CacheManager
-import me.ahoo.cache.CacheSource
 import me.ahoo.cache.CoherentCache
 import me.ahoo.cache.annotation.CoCacheMetadata
 import me.ahoo.cache.annotation.coCacheMetadata
+import me.ahoo.cache.api.source.CacheSource
 import me.ahoo.cache.consistency.NoOpCacheEvictedEventBus
 import me.ahoo.cache.distributed.DistributedCache
 import me.ahoo.cache.distributed.DistributedCacheFactory

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/MockCache.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/MockCache.kt
@@ -13,8 +13,8 @@
 
 package me.ahoo.cache.proxy
 
-import me.ahoo.cache.Cache
+import me.ahoo.cache.ComputedCache
 import me.ahoo.cache.api.annotation.CoCache
 
 @CoCache
-interface MockCache : Cache<String, String>
+interface MockCache : ComputedCache<String, String>

--- a/cocache-example/src/main/kotlin/me/ahoo/cache/example/cache/UserCacheProxy.kt
+++ b/cocache-example/src/main/kotlin/me/ahoo/cache/example/cache/UserCacheProxy.kt
@@ -13,9 +13,9 @@
 
 package me.ahoo.cache.example.cache
 
-import me.ahoo.cache.Cache
+import me.ahoo.cache.ComputedCache
 import me.ahoo.cache.api.annotation.CoCache
 import me.ahoo.cache.example.model.User
 
 @CoCache
-interface UserCacheProxy : Cache<String, User>
+interface UserCacheProxy : ComputedCache<String, User>

--- a/cocache-example/src/main/kotlin/me/ahoo/cache/example/config/CacheConfiguration.kt
+++ b/cocache-example/src/main/kotlin/me/ahoo/cache/example/config/CacheConfiguration.kt
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.cache.CacheBuilder
 import me.ahoo.cache.CacheConfig
 import me.ahoo.cache.CacheManager
-import me.ahoo.cache.CacheValue
+import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.CoherentCache
 import me.ahoo.cache.client.GuavaClientSideCache
 import me.ahoo.cache.converter.ToStringKeyConverter

--- a/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheClientEndpoint.kt
+++ b/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheClientEndpoint.kt
@@ -14,7 +14,7 @@
 package me.ahoo.cache.spring.boot.starter
 
 import me.ahoo.cache.CacheManager
-import me.ahoo.cache.CacheValue
+import me.ahoo.cache.api.CacheValue
 import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation

--- a/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheEndpoint.kt
+++ b/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheEndpoint.kt
@@ -14,8 +14,8 @@
 package me.ahoo.cache.spring.boot.starter
 
 import me.ahoo.cache.CacheManager
-import me.ahoo.cache.CacheValue
 import me.ahoo.cache.CoherentCache
+import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.api.annotation.CoCache
 import me.ahoo.cache.spring.boot.starter.CoCacheEndpoint.CacheReport.Companion.asReport
 import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation

--- a/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/RedisDistributedCache.kt
+++ b/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/RedisDistributedCache.kt
@@ -12,8 +12,8 @@
  */
 package me.ahoo.cache.spring.redis
 
-import me.ahoo.cache.CacheValue
-import me.ahoo.cache.TtlAt
+import me.ahoo.cache.ComputedTtlAt
+import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.distributed.DistributedCache
 import me.ahoo.cache.spring.redis.codec.CodecExecutor
 import me.ahoo.cache.util.CacheSecondClock
@@ -39,7 +39,7 @@ class RedisDistributedCache<V>(
             return null
         }
         return if (FOREVER == ttl) {
-            TtlAt.FOREVER
+            ComputedTtlAt.FOREVER
         } else {
             CacheSecondClock.INSTANCE.currentTime() + ttl
         }

--- a/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/AbstractCodecExecutor.kt
+++ b/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/AbstractCodecExecutor.kt
@@ -13,19 +13,20 @@
 
 package me.ahoo.cache.spring.redis.codec
 
-import me.ahoo.cache.CacheValue
+import me.ahoo.cache.DefaultCacheValue
+import me.ahoo.cache.api.CacheValue
 
 abstract class AbstractCodecExecutor<V, RAW_VALUE> : CodecExecutor<V> {
 
     abstract fun CacheValue<V>.toRawValue(): RAW_VALUE
 
     override fun executeAndDecode(key: String, ttlAt: Long): CacheValue<V> {
-        val rawValue = getRawValue(key) ?: return CacheValue.missingGuard(ttlAt)
+        val rawValue = getRawValue(key) ?: return DefaultCacheValue.missingGuard(ttlAt)
         return if (isMissingGuard(rawValue)) {
-            CacheValue.missingGuard(ttlAt)
+            DefaultCacheValue.missingGuard(ttlAt)
         } else {
             val value = decode(rawValue)
-            CacheValue(
+            DefaultCacheValue(
                 value,
                 ttlAt,
             )

--- a/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/MapToHashCodecExecutor.kt
+++ b/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/MapToHashCodecExecutor.kt
@@ -12,8 +12,9 @@
  */
 package me.ahoo.cache.spring.redis.codec
 
-import me.ahoo.cache.CacheValue
+import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.MissingGuard
+import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.util.CacheSecondClock
 import org.springframework.data.redis.connection.StringRedisConnection
 import org.springframework.data.redis.core.StringRedisTemplate
@@ -38,7 +39,7 @@ class MapToHashCodecExecutor(private val redisTemplate: StringRedisTemplate) :
     }
 
     override fun isMissingGuard(rawValue: Map<String, String>): Boolean {
-        return CacheValue.isMissingGuard(rawValue)
+        return DefaultCacheValue.isMissingGuard(rawValue)
     }
 
     override fun decode(rawValue: Map<String, String>): Map<String, String> {

--- a/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/ObjectToHashCodecExecutor.kt
+++ b/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/ObjectToHashCodecExecutor.kt
@@ -12,8 +12,9 @@
  */
 package me.ahoo.cache.spring.redis.codec
 
-import me.ahoo.cache.CacheValue
+import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.MissingGuard
+import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.util.CacheSecondClock
 import org.springframework.data.redis.connection.StringRedisConnection
 import org.springframework.data.redis.core.StringRedisTemplate
@@ -63,7 +64,7 @@ class ObjectToHashCodecExecutor<V>(
     }
 
     override fun isMissingGuard(rawValue: Map<String, String>): Boolean {
-        return CacheValue.isMissingGuard(rawValue)
+        return DefaultCacheValue.isMissingGuard(rawValue)
     }
 
     interface MapConverter<V> {

--- a/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/ObjectToJsonCodecExecutor.kt
+++ b/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/ObjectToJsonCodecExecutor.kt
@@ -13,8 +13,9 @@
 package me.ahoo.cache.spring.redis.codec
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import me.ahoo.cache.CacheValue
+import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.MissingGuard
+import me.ahoo.cache.api.CacheValue
 import org.springframework.data.redis.core.StringRedisTemplate
 
 /**
@@ -36,7 +37,7 @@ class ObjectToJsonCodecExecutor<V>(
     }
 
     override fun isMissingGuard(rawValue: String): Boolean {
-        return CacheValue.isMissingGuard(rawValue)
+        return DefaultCacheValue.isMissingGuard(rawValue)
     }
 
     override fun getRawValue(key: String): String? {

--- a/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/SetToSetCodecExecutor.kt
+++ b/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/SetToSetCodecExecutor.kt
@@ -12,8 +12,9 @@
  */
 package me.ahoo.cache.spring.redis.codec
 
-import me.ahoo.cache.CacheValue
+import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.MissingGuard
+import me.ahoo.cache.api.CacheValue
 import org.springframework.data.redis.connection.StringRedisConnection
 import org.springframework.data.redis.core.StringRedisTemplate
 
@@ -35,7 +36,7 @@ class SetToSetCodecExecutor(private val redisTemplate: StringRedisTemplate) :
     }
 
     override fun isMissingGuard(rawValue: Set<String>): Boolean {
-        return CacheValue.isMissingGuard(rawValue)
+        return DefaultCacheValue.isMissingGuard(rawValue)
     }
 
     override fun getRawValue(key: String): Set<String>? {

--- a/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/StringToStringCodecExecutor.kt
+++ b/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/StringToStringCodecExecutor.kt
@@ -12,8 +12,9 @@
  */
 package me.ahoo.cache.spring.redis.codec
 
-import me.ahoo.cache.CacheValue
+import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.MissingGuard
+import me.ahoo.cache.api.CacheValue
 import org.springframework.data.redis.core.StringRedisTemplate
 
 /**
@@ -32,7 +33,7 @@ class StringToStringCodecExecutor(private val redisTemplate: StringRedisTemplate
     }
 
     override fun isMissingGuard(rawValue: String): Boolean {
-        return CacheValue.isMissingGuard(rawValue)
+        return DefaultCacheValue.isMissingGuard(rawValue)
     }
 
     override fun getRawValue(key: String): String? {

--- a/cocache-spring-redis/src/test/kotlin/me/ahoo/cache/spring/redis/codec/CodecExecutorSpec.kt
+++ b/cocache-spring-redis/src/test/kotlin/me/ahoo/cache/spring/redis/codec/CodecExecutorSpec.kt
@@ -13,8 +13,9 @@
 
 package me.ahoo.cache.spring.redis.codec
 
-import me.ahoo.cache.CacheValue
-import me.ahoo.cache.TtlAt
+import me.ahoo.cache.ComputedTtlAt
+import me.ahoo.cache.DefaultCacheValue
+import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.util.CacheSecondClock
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
@@ -53,9 +54,9 @@ abstract class CodecExecutorSpec<V> {
     @Test
     fun executeAndEncode() {
         val key = "executeAndDecode:" + UUID.randomUUID().toString()
-        val value = CacheValue.forever(createCacheValue())
+        val value = DefaultCacheValue.forever(createCacheValue())
         codecExecutor.executeAndEncode(key, value)
-        val actual = codecExecutor.executeAndDecode(key, TtlAt.FOREVER)
+        val actual = codecExecutor.executeAndDecode(key, ComputedTtlAt.FOREVER)
         assertThat(actual, equalTo(value))
     }
 
@@ -63,7 +64,7 @@ abstract class CodecExecutorSpec<V> {
     fun executeAndEncodeWithTtlAt() {
         val key = "executeAndDecode:" + UUID.randomUUID().toString()
         val ttlAt = CacheSecondClock.INSTANCE.currentTime() + 10
-        val value = CacheValue(createCacheValue(), ttlAt)
+        val value = DefaultCacheValue(createCacheValue(), ttlAt)
         codecExecutor.executeAndEncode(key, value)
         val actual = codecExecutor.executeAndDecode(key, ttlAt)
         assertThat(actual.value, equalTo(value.value))
@@ -73,16 +74,16 @@ abstract class CodecExecutorSpec<V> {
     @Test
     fun executeAndEncodeMissing() {
         val key = "executeAndDecodeWhenMissing:" + UUID.randomUUID().toString()
-        val value = CacheValue.missingGuard<CacheValue<V>>()
+        val value = DefaultCacheValue.missingGuard<CacheValue<V>>()
         codecExecutor.executeAndEncode(key, value)
-        val actual = codecExecutor.executeAndDecode(key, TtlAt.FOREVER)
+        val actual = codecExecutor.executeAndDecode(key, ComputedTtlAt.FOREVER)
         assertThat(actual, equalTo(value))
     }
 
     @Test
     fun executeAndEncodeMissingWithTtlAt() {
         val key = "executeAndDecodeWhenMissingTtl:" + UUID.randomUUID().toString()
-        val value = CacheValue.missingGuard<CacheValue<V>>(100)
+        val value = DefaultCacheValue.missingGuard<CacheValue<V>>(100)
         codecExecutor.executeAndEncode(key, value)
         val actual = codecExecutor.executeAndDecode(key, 100)
         assertThat(actual.value, equalTo(value.value))

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/EnableCoCache.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/EnableCoCache.kt
@@ -13,7 +13,7 @@
 
 package me.ahoo.cache.spring
 
-import me.ahoo.cache.Cache
+import me.ahoo.cache.api.Cache
 import org.springframework.context.annotation.Import
 import kotlin.reflect.KClass
 

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/proxy/CacheProxyFactoryBean.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/proxy/CacheProxyFactoryBean.kt
@@ -13,8 +13,8 @@
 
 package me.ahoo.cache.spring.proxy
 
-import me.ahoo.cache.Cache
 import me.ahoo.cache.annotation.CoCacheMetadata
+import me.ahoo.cache.api.Cache
 import me.ahoo.cache.proxy.CacheProxyFactory
 import org.springframework.beans.factory.FactoryBean
 import org.springframework.context.ApplicationContext

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/proxy/SpringCacheSourceResolver.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/proxy/SpringCacheSourceResolver.kt
@@ -13,8 +13,8 @@
 
 package me.ahoo.cache.spring.proxy
 
-import me.ahoo.cache.CacheSource
 import me.ahoo.cache.annotation.CoCacheMetadata
+import me.ahoo.cache.api.source.CacheSource
 import me.ahoo.cache.proxy.CacheSourceResolver
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.core.ResolvableType

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/CacheSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/CacheSpec.kt
@@ -13,9 +13,9 @@
 
 package me.ahoo.cache.test
 
-import me.ahoo.cache.Cache
-import me.ahoo.cache.CacheValue
-import me.ahoo.cache.TtlAt
+import me.ahoo.cache.ComputedTtlAt
+import me.ahoo.cache.DefaultCacheValue
+import me.ahoo.cache.api.Cache
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.nullValue
@@ -42,7 +42,7 @@ abstract class CacheSpec<K, V> {
     @Test
     fun getWhenExpired() {
         val (key, value) = createCacheEntry()
-        val ttlAt = TtlAt.at(-5)
+        val ttlAt = ComputedTtlAt.at(-5)
         cache[key, ttlAt] = value
         assertThat(cache[key], nullValue())
         assertThat(cache.getTtlAt(key), nullValue())
@@ -60,7 +60,7 @@ abstract class CacheSpec<K, V> {
     fun setWithTtl() {
         val (key, value) = createCacheEntry()
         assertThat(cache[key], nullValue())
-        val cacheValue = CacheValue.ttlAt(value, 5)
+        val cacheValue = DefaultCacheValue.ttlAt(value, 5)
         cache.setCache(key, cacheValue)
         assertThat(cache[key], equalTo(value))
         assertThat(cache.getTtlAt(key), equalTo(cacheValue.ttlAt))
@@ -70,7 +70,7 @@ abstract class CacheSpec<K, V> {
     fun setWithTtlAmplitude() {
         val (key, value) = createCacheEntry()
         assertThat(cache[key], nullValue())
-        val cacheValue = CacheValue.ttlAt(value, 5, 1)
+        val cacheValue = DefaultCacheValue.ttlAt(value, 5, 1)
         cache.setCache(key, cacheValue)
         assertThat(cache[key], equalTo(value))
         assertThat(cache.getTtlAt(key), equalTo(cacheValue.ttlAt))
@@ -88,7 +88,7 @@ abstract class CacheSpec<K, V> {
     @Test
     fun setMissing() {
         val (key, value) = createCacheEntry()
-        cache[key] = CacheValue.missingGuardValue()
+        cache[key] = DefaultCacheValue.missingGuardValue()
         Assertions.assertNull(cache[key])
         Assertions.assertNull(cache.getTtlAt(key))
     }
@@ -96,7 +96,7 @@ abstract class CacheSpec<K, V> {
     @Test
     fun setMissingTtl() {
         val (key, value) = createCacheEntry()
-        cache.setCache(key, CacheValue.missingGuard(5))
+        cache.setCache(key, DefaultCacheValue.missingGuard(5))
         Assertions.assertNull(cache[key])
         Assertions.assertNull(cache.getTtlAt(key))
     }

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/CoherentCacheSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/CoherentCacheSpec.kt
@@ -13,10 +13,11 @@
 
 package me.ahoo.cache.test
 
-import me.ahoo.cache.Cache
-import me.ahoo.cache.CacheSource
-import me.ahoo.cache.CacheValue
 import me.ahoo.cache.CoherentCache
+import me.ahoo.cache.DefaultCacheValue
+import me.ahoo.cache.api.Cache
+import me.ahoo.cache.api.CacheValue
+import me.ahoo.cache.api.source.CacheSource
 import me.ahoo.cache.client.ClientSideCache
 import me.ahoo.cache.consistency.CacheEvictedEvent
 import me.ahoo.cache.consistency.CacheEvictedEventBus
@@ -80,7 +81,7 @@ abstract class CoherentCacheSpec<K, V> : CacheSpec<K, V>() {
     @Test
     fun getFromCacheSource() {
         val (key, value) = createCacheEntry()
-        val cacheValue = CacheValue.forever(value)
+        val cacheValue = DefaultCacheValue.forever(value)
         CACHE_SOURCE_VALUE.set(cacheValue)
         assertThat(coherentCache[key], equalTo(value))
         CACHE_SOURCE_VALUE.remove()
@@ -89,7 +90,7 @@ abstract class CoherentCacheSpec<K, V> : CacheSpec<K, V>() {
     @Test
     fun onEvicted() {
         val (key, value) = createCacheEntry()
-        val cacheValue = CacheValue.forever(value)
+        val cacheValue = DefaultCacheValue.forever(value)
         coherentCache.setCache(key, cacheValue)
         val cacheKey = keyConverter.asKey(key)
         val event = CacheEvictedEvent(cacheName, cacheKey, "")
@@ -102,7 +103,7 @@ abstract class CoherentCacheSpec<K, V> : CacheSpec<K, V>() {
     @Test
     fun onEvictedWhenLoop() {
         val (key, value) = createCacheEntry()
-        val cacheValue = CacheValue.forever(value)
+        val cacheValue = DefaultCacheValue.forever(value)
         coherentCache.setCache(key, cacheValue)
         val cacheKey = keyConverter.asKey(key)
         val event = CacheEvictedEvent(cacheName, cacheKey, clientId)
@@ -115,7 +116,7 @@ abstract class CoherentCacheSpec<K, V> : CacheSpec<K, V>() {
     @Test
     fun onEvictedWhenCacheNameNotMatch() {
         val (key, value) = createCacheEntry()
-        val cacheValue = CacheValue.forever(value)
+        val cacheValue = DefaultCacheValue.forever(value)
         coherentCache.setCache(key, cacheValue)
         val cacheKey = keyConverter.asKey(key)
         val event = CacheEvictedEvent(UUID.randomUUID().toString(), cacheKey, "")


### PR DESCRIPTION
- Move Cache, CacheValue, and related interfaces to api module
- Create ComputedCache and ComputedTtlAt interfaces in core module
- Update dependencies across modules to use new api package
- Rename CacheValue to DefaultCacheValue in core module
- Adjust test cases and configuration to reflect new structure