### PR TITLE
feat(core): add client side cache factory support

### DIFF
--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/ClientSideCacheFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/ClientSideCacheFactory.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cache.client
+
+import me.ahoo.cache.annotation.CoCacheMetadata
+
+@FunctionalInterface
+interface ClientSideCacheFactory {
+    fun <V> create(cacheMetadata: CoCacheMetadata): ClientSideCache<V>
+}

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/GuavaClientSideCacheFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/GuavaClientSideCacheFactory.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cache.client
+
+import me.ahoo.cache.annotation.CoCacheMetadata
+
+object GuavaClientSideCacheFactory : ClientSideCacheFactory {
+    override fun <V> create(cacheMetadata: CoCacheMetadata): ClientSideCache<V> {
+        return GuavaClientSideCache()
+    }
+}

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/MapClientSideCacheFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/MapClientSideCacheFactory.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cache.client
+
+import me.ahoo.cache.annotation.CoCacheMetadata
+
+object MapClientSideCacheFactory : ClientSideCacheFactory {
+    override fun <V> create(cacheMetadata: CoCacheMetadata): ClientSideCache<V> {
+        return MapClientSideCache()
+    }
+}

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/client/GuavaClientSideCacheFactoryTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/client/GuavaClientSideCacheFactoryTest.kt
@@ -1,0 +1,16 @@
+package me.ahoo.cache.client
+
+import me.ahoo.cache.annotation.coCacheMetadata
+import me.ahoo.cache.proxy.MockCache
+import org.hamcrest.CoreMatchers.instanceOf
+import org.hamcrest.MatcherAssert.*
+import org.junit.jupiter.api.Test
+
+class GuavaClientSideCacheFactoryTest {
+
+    @Test
+    fun create() {
+        val clientSideCache = GuavaClientSideCacheFactory.create<Any>(coCacheMetadata<MockCache>())
+        assertThat(clientSideCache, instanceOf(GuavaClientSideCache::class.java))
+    }
+}

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/client/MapClientSideCacheFactoryTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/client/MapClientSideCacheFactoryTest.kt
@@ -1,0 +1,16 @@
+package me.ahoo.cache.client
+
+import me.ahoo.cache.annotation.coCacheMetadata
+import me.ahoo.cache.proxy.MockCache
+import org.hamcrest.CoreMatchers.instanceOf
+import org.hamcrest.MatcherAssert.*
+import org.junit.jupiter.api.Test
+
+class MapClientSideCacheFactoryTest {
+
+    @Test
+    fun create() {
+        val clientSideCache = MapClientSideCacheFactory.create<Any>(coCacheMetadata<MockCache>())
+        assertThat(clientSideCache, instanceOf(MapClientSideCache::class.java))
+    }
+}

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactoryTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactoryTest.kt
@@ -5,6 +5,7 @@ import me.ahoo.cache.CoherentCache
 import me.ahoo.cache.annotation.CoCacheMetadata
 import me.ahoo.cache.annotation.coCacheMetadata
 import me.ahoo.cache.api.source.CacheSource
+import me.ahoo.cache.client.MapClientSideCacheFactory
 import me.ahoo.cache.consistency.NoOpCacheEvictedEventBus
 import me.ahoo.cache.distributed.DistributedCache
 import me.ahoo.cache.distributed.DistributedCacheFactory
@@ -30,6 +31,7 @@ class DefaultCacheProxyFactoryTest {
         val cacheProxyFactory = DefaultCacheProxyFactory(
             cacheManager = CacheManager(NoOpCacheEvictedEventBus),
             clientIdGenerator = ClientIdGenerator.UUID,
+            clientSideCacheFactory = MapClientSideCacheFactory,
             distributedCacheFactory = distributedCacheFactory,
             cacheSourceResolver = cacheSourceResolver
         )

--- a/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfiguration.kt
+++ b/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfiguration.kt
@@ -13,6 +13,8 @@
 package me.ahoo.cache.spring.boot.starter
 
 import me.ahoo.cache.CacheManager
+import me.ahoo.cache.client.ClientSideCacheFactory
+import me.ahoo.cache.client.MapClientSideCacheFactory
 import me.ahoo.cache.consistency.CacheEvictedEventBus
 import me.ahoo.cache.distributed.DistributedCacheFactory
 import me.ahoo.cache.proxy.CacheProxyFactory
@@ -90,6 +92,12 @@ class CoCacheAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    fun clientSideCacheFactory(): ClientSideCacheFactory {
+        return MapClientSideCacheFactory
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
     fun distributedCacheFactory(redisTemplate: StringRedisTemplate): DistributedCacheFactory {
         return RedisDistributedCacheFactory(redisTemplate)
     }
@@ -99,10 +107,17 @@ class CoCacheAutoConfiguration {
     fun cacheProxyFactory(
         cacheManager: CacheManager,
         clientIdGenerator: ClientIdGenerator,
+        clientSideCacheFactory: ClientSideCacheFactory,
         distributedCacheFactory: DistributedCacheFactory,
         cacheSourceResolver: CacheSourceResolver
     ): CacheProxyFactory {
-        return DefaultCacheProxyFactory(cacheManager, clientIdGenerator, distributedCacheFactory, cacheSourceResolver)
+        return DefaultCacheProxyFactory(
+            cacheManager,
+            clientIdGenerator,
+            clientSideCacheFactory,
+            distributedCacheFactory,
+            cacheSourceResolver
+        )
     }
 
     @Configuration


### PR DESCRIPTION
- Introduce ClientSideCacheFactory interface and its implementations
- Integrate client side cache into DefaultCacheProxyFactory
- Add auto-configuration for client side cache factory in Spring Boot starter
- Implement MapClientSideCacheFactory and GuavaClientSideCacheFactory
