### PR TITLE
refactor(cocache): rename CacheSourceResolver to CacheSourceFactory

### DIFF
--- a/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactory.kt
@@ -25,6 +25,7 @@ import me.ahoo.cache.client.ClientSideCacheFactory
 import me.ahoo.cache.converter.ToStringKeyConverter
 import me.ahoo.cache.distributed.DistributedCache
 import me.ahoo.cache.distributed.DistributedCacheFactory
+import me.ahoo.cache.source.CacheSourceFactory
 import me.ahoo.cache.util.ClientIdGenerator
 import java.lang.reflect.Proxy
 
@@ -33,13 +34,13 @@ class DefaultCacheProxyFactory(
     private val clientIdGenerator: ClientIdGenerator,
     private val clientSideCacheFactory: ClientSideCacheFactory,
     private val distributedCacheFactory: DistributedCacheFactory,
-    private val cacheSourceResolver: CacheSourceResolver
+    private val cacheSourceFactory: CacheSourceFactory
 ) : CacheProxyFactory {
 
     @Suppress("UNCHECKED_CAST")
     override fun <CACHE : Cache<*, *>> create(cacheMetadata: CoCacheMetadata): CACHE {
         val clientId = clientIdGenerator.generate()
-        val cacheSource = cacheSourceResolver.resolve<Any>(cacheMetadata)
+        val cacheSource = cacheSourceFactory.create<Any>(cacheMetadata)
         val clientSideCaching: ClientSideCache<Any> = clientSideCacheFactory.create(cacheMetadata)
         val distributedCaching: DistributedCache<Any> = distributedCacheFactory.create(cacheMetadata)
         val delegate = cacheManager.getOrCreateCache(

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/source/CacheSourceFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/source/CacheSourceFactory.kt
@@ -11,12 +11,12 @@
  * limitations under the License.
  */
 
-package me.ahoo.cache.proxy
+package me.ahoo.cache.source
 
 import me.ahoo.cache.annotation.CoCacheMetadata
 import me.ahoo.cache.api.source.CacheSource
 
 @FunctionalInterface
-interface CacheSourceResolver {
-    fun <V> resolve(cacheMetadata: CoCacheMetadata): CacheSource<String, V>
+interface CacheSourceFactory {
+    fun <V> create(cacheMetadata: CoCacheMetadata): CacheSource<String, V>
 }

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactoryTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactoryTest.kt
@@ -10,6 +10,7 @@ import me.ahoo.cache.consistency.NoOpCacheEvictedEventBus
 import me.ahoo.cache.distributed.DistributedCache
 import me.ahoo.cache.distributed.DistributedCacheFactory
 import me.ahoo.cache.distributed.mock.MockDistributedCache
+import me.ahoo.cache.source.CacheSourceFactory
 import me.ahoo.cache.util.ClientIdGenerator
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -23,8 +24,8 @@ class DefaultCacheProxyFactoryTest {
                     return MockDistributedCache()
                 }
             }
-            val cacheSourceResolver = object : CacheSourceResolver {
-                override fun <V> resolve(cacheMetadata: CoCacheMetadata): CacheSource<String, V> {
+            val cacheSourceFactory = object : CacheSourceFactory {
+                override fun <V> create(cacheMetadata: CoCacheMetadata): CacheSource<String, V> {
                     return CacheSource.noOp()
                 }
             }
@@ -33,7 +34,7 @@ class DefaultCacheProxyFactoryTest {
                 clientIdGenerator = ClientIdGenerator.UUID,
                 clientSideCacheFactory = MapClientSideCacheFactory,
                 distributedCacheFactory = distributedCacheFactory,
-                cacheSourceResolver = cacheSourceResolver
+                cacheSourceFactory = cacheSourceFactory
             )
             return cacheProxyFactory.create(coCacheMetadata<MockCache>())
         }

--- a/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfiguration.kt
+++ b/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfiguration.kt
@@ -20,9 +20,9 @@ import me.ahoo.cache.distributed.DistributedCacheFactory
 import me.ahoo.cache.proxy.CacheProxyFactory
 import me.ahoo.cache.proxy.DefaultCacheProxyFactory
 import me.ahoo.cache.source.CacheSourceFactory
-import me.ahoo.cache.spring.proxy.SpringCacheSourceFactory
 import me.ahoo.cache.spring.redis.RedisCacheEvictedEventBus
 import me.ahoo.cache.spring.redis.RedisDistributedCacheFactory
+import me.ahoo.cache.spring.souce.SpringCacheSourceFactory
 import me.ahoo.cache.util.ClientIdGenerator
 import me.ahoo.cache.util.HostClientIdGenerator
 import me.ahoo.cosid.machine.HostAddressSupplier

--- a/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfiguration.kt
+++ b/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfiguration.kt
@@ -18,9 +18,9 @@ import me.ahoo.cache.client.MapClientSideCacheFactory
 import me.ahoo.cache.consistency.CacheEvictedEventBus
 import me.ahoo.cache.distributed.DistributedCacheFactory
 import me.ahoo.cache.proxy.CacheProxyFactory
-import me.ahoo.cache.proxy.CacheSourceResolver
 import me.ahoo.cache.proxy.DefaultCacheProxyFactory
-import me.ahoo.cache.spring.proxy.SpringCacheSourceResolver
+import me.ahoo.cache.source.CacheSourceFactory
+import me.ahoo.cache.spring.proxy.SpringCacheSourceFactory
 import me.ahoo.cache.spring.redis.RedisCacheEvictedEventBus
 import me.ahoo.cache.spring.redis.RedisDistributedCacheFactory
 import me.ahoo.cache.util.ClientIdGenerator
@@ -86,8 +86,8 @@ class CoCacheAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun cacheSourceResolver(beanFactory: BeanFactory): CacheSourceResolver {
-        return SpringCacheSourceResolver(beanFactory)
+    fun cacheSourceFactory(beanFactory: BeanFactory): CacheSourceFactory {
+        return SpringCacheSourceFactory(beanFactory)
     }
 
     @Bean
@@ -109,7 +109,7 @@ class CoCacheAutoConfiguration {
         clientIdGenerator: ClientIdGenerator,
         clientSideCacheFactory: ClientSideCacheFactory,
         distributedCacheFactory: DistributedCacheFactory,
-        cacheSourceResolver: CacheSourceResolver
+        cacheSourceResolver: CacheSourceFactory
     ): CacheProxyFactory {
         return DefaultCacheProxyFactory(
             cacheManager,

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/proxy/SpringCacheSourceFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/proxy/SpringCacheSourceFactory.kt
@@ -15,13 +15,13 @@ package me.ahoo.cache.spring.proxy
 
 import me.ahoo.cache.annotation.CoCacheMetadata
 import me.ahoo.cache.api.source.CacheSource
-import me.ahoo.cache.proxy.CacheSourceResolver
+import me.ahoo.cache.source.CacheSourceFactory
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.core.ResolvableType
 
-class SpringCacheSourceResolver(private val beanFactory: BeanFactory) : CacheSourceResolver {
+class SpringCacheSourceFactory(private val beanFactory: BeanFactory) : CacheSourceFactory {
     @Suppress("UNCHECKED_CAST")
-    override fun <V> resolve(cacheMetadata: CoCacheMetadata): CacheSource<String, V> {
+    override fun <V> create(cacheMetadata: CoCacheMetadata): CacheSource<String, V> {
         val cacheSourceType = ResolvableType.forClassWithGenerics(
             CacheSource::class.java,
             String::class.java,

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/souce/SpringCacheSourceFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/souce/SpringCacheSourceFactory.kt
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package me.ahoo.cache.spring.proxy
+package me.ahoo.cache.spring.souce
 
 import me.ahoo.cache.annotation.CoCacheMetadata
 import me.ahoo.cache.api.source.CacheSource


### PR DESCRIPTION
- Rename CacheSourceResolver interface to CacheSourceFactory
- Update related implementations and imports
- Adjust package structure for better organization

