### PR TITLE
refactor(client-side-cache): move ClientSideCache interface to API module

### DIFF
--- a/cocache-api/src/main/kotlin/me/ahoo/cache/api/client/ClientSideCache.kt
+++ b/cocache-api/src/main/kotlin/me/ahoo/cache/api/client/ClientSideCache.kt
@@ -10,27 +10,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package me.ahoo.cache.client
+package me.ahoo.cache.api.client
 
-import me.ahoo.cache.ComputedCache
+import me.ahoo.cache.api.Cache
 
 /**
  * Client Side Cache .
  *
  * @author ahoo wang
  */
-interface ClientSideCache<V> : ComputedCache<String, V> {
-    override fun get(key: String): V? {
-        val cacheValue = getCache(key) ?: return null
-        if (cacheValue.isExpired) {
-            evict(key)
-            return null
-        }
-        if (cacheValue.isMissingGuard) {
-            return null
-        }
-        return cacheValue.value
-    }
+interface ClientSideCache<V> : Cache<String, V> {
 
     val size: Long
 

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/CacheManager.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/CacheManager.kt
@@ -13,8 +13,8 @@
 
 package me.ahoo.cache
 
+import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.api.source.CacheSource
-import me.ahoo.cache.client.ClientSideCache
 import me.ahoo.cache.client.MapClientSideCache
 import me.ahoo.cache.consistency.CacheEvictedEventBus
 import me.ahoo.cache.converter.KeyConverter

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/CoherentCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/CoherentCache.kt
@@ -14,8 +14,8 @@ package me.ahoo.cache
 
 import com.google.common.eventbus.Subscribe
 import me.ahoo.cache.api.CacheValue
+import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.api.source.CacheSource
-import me.ahoo.cache.client.ClientSideCache
 import me.ahoo.cache.client.MapClientSideCache
 import me.ahoo.cache.consistency.CacheEvictedEvent
 import me.ahoo.cache.consistency.CacheEvictedEventBus

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/ClientSideCacheFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/ClientSideCacheFactory.kt
@@ -14,6 +14,7 @@
 package me.ahoo.cache.client
 
 import me.ahoo.cache.annotation.CoCacheMetadata
+import me.ahoo.cache.api.client.ClientSideCache
 
 @FunctionalInterface
 interface ClientSideCacheFactory {

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/ComputedClientSideCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/ComputedClientSideCache.kt
@@ -10,24 +10,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package me.ahoo.cache.client
 
+import me.ahoo.cache.ComputedCache
 import me.ahoo.cache.api.client.ClientSideCache
-import me.ahoo.cache.test.ClientSideCacheSpec
-import java.util.*
 
-/**
- * MapClientSideCachingTest .
- *
- * @author ahoo wang
- */
-internal class MapClientSideCacheTest : ClientSideCacheSpec<String>() {
-
-    override fun createCache(): ClientSideCache<String> {
-        return MapClientSideCache()
-    }
-
-    override fun createCacheEntry(): Pair<String, String> {
-        return UUID.randomUUID().toString() to UUID.randomUUID().toString()
+interface ComputedClientSideCache<V> : ClientSideCache<V>, ComputedCache<String, V> {
+    override fun get(key: String): V? {
+        val cacheValue = getCache(key) ?: return null
+        if (cacheValue.isExpired) {
+            evict(key)
+            return null
+        }
+        if (cacheValue.isMissingGuard) {
+            return null
+        }
+        return cacheValue.value
     }
 }

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/GuavaClientSideCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/GuavaClientSideCache.kt
@@ -23,7 +23,7 @@ import me.ahoo.cache.api.CacheValue
  */
 class GuavaClientSideCache<V>(
     private val guavaCache: Cache<String, CacheValue<V>> = CacheBuilder.newBuilder().build()
-) : ClientSideCache<V> {
+) : ComputedClientSideCache<V> {
 
     override fun getCache(key: String): CacheValue<V>? {
         return guavaCache.getIfPresent(key)

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/GuavaClientSideCacheFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/GuavaClientSideCacheFactory.kt
@@ -14,6 +14,7 @@
 package me.ahoo.cache.client
 
 import me.ahoo.cache.annotation.CoCacheMetadata
+import me.ahoo.cache.api.client.ClientSideCache
 
 object GuavaClientSideCacheFactory : ClientSideCacheFactory {
     override fun <V> create(cacheMetadata: CoCacheMetadata): ClientSideCache<V> {

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/MapClientSideCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/MapClientSideCache.kt
@@ -22,8 +22,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 class MapClientSideCache<V>(
     private val cacheMap: MutableMap<String, CacheValue<V>> = ConcurrentHashMap()
-) :
-    ClientSideCache<V> {
+) : ComputedClientSideCache<V> {
     override fun getCache(key: String): CacheValue<V>? {
         return cacheMap[key]
     }

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/MapClientSideCacheFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/MapClientSideCacheFactory.kt
@@ -14,6 +14,7 @@
 package me.ahoo.cache.client
 
 import me.ahoo.cache.annotation.CoCacheMetadata
+import me.ahoo.cache.api.client.ClientSideCache
 
 object MapClientSideCacheFactory : ClientSideCacheFactory {
     override fun <V> create(cacheMetadata: CoCacheMetadata): ClientSideCache<V> {

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactory.kt
@@ -20,7 +20,7 @@ import me.ahoo.cache.annotation.CoCacheMetadata
 import me.ahoo.cache.api.Cache
 import me.ahoo.cache.api.NamedCache
 import me.ahoo.cache.api.annotation.CoCache
-import me.ahoo.cache.client.ClientSideCache
+import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.client.ClientSideCacheFactory
 import me.ahoo.cache.converter.ToStringKeyConverter
 import me.ahoo.cache.distributed.DistributedCache

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/CoherentCacheTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/CoherentCacheTest.kt
@@ -12,7 +12,7 @@
  */
 package me.ahoo.cache
 
-import me.ahoo.cache.client.ClientSideCache
+import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.client.MapClientSideCache
 import me.ahoo.cache.consistency.CacheEvictedEventBus
 import me.ahoo.cache.consistency.GuavaCacheEvictedEventBus

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/MemoryMultipleInstanceSyncTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/MemoryMultipleInstanceSyncTest.kt
@@ -13,7 +13,7 @@
 
 package me.ahoo.cache
 
-import me.ahoo.cache.client.ClientSideCache
+import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.client.MapClientSideCache
 import me.ahoo.cache.consistency.CacheEvictedEventBus
 import me.ahoo.cache.consistency.GuavaCacheEvictedEventBus

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/client/GuavaClientSideCacheTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/client/GuavaClientSideCacheTest.kt
@@ -12,6 +12,7 @@
  */
 package me.ahoo.cache.client
 
+import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.test.ClientSideCacheSpec
 import java.util.*
 

--- a/cocache-example/src/main/kotlin/me/ahoo/cache/example/config/UserCacheConfiguration.kt
+++ b/cocache-example/src/main/kotlin/me/ahoo/cache/example/config/UserCacheConfiguration.kt
@@ -13,7 +13,7 @@
 package me.ahoo.cache.example.config
 
 import me.ahoo.cache.api.source.CacheSource
-import me.ahoo.cache.client.ClientSideCache
+import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.client.MapClientSideCache
 import me.ahoo.cache.example.model.User
 import org.springframework.context.annotation.Bean

--- a/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/customize/EnableCoCacheConfigurationWithCustomize.kt
+++ b/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/customize/EnableCoCacheConfigurationWithCustomize.kt
@@ -15,7 +15,7 @@ package me.ahoo.cache.spring.boot.starter.customize
 
 import io.mockk.mockk
 import me.ahoo.cache.api.source.CacheSource
-import me.ahoo.cache.client.ClientSideCache
+import me.ahoo.cache.client.ComputedClientSideCache
 import me.ahoo.cache.example.cache.UserCache
 import me.ahoo.cache.example.model.User
 import me.ahoo.cache.spring.EnableCoCache
@@ -31,7 +31,7 @@ import org.springframework.context.annotation.Bean
 class EnableCoCacheConfigurationWithCustomize {
 
     @Bean
-    fun customizeUserClientSideCache(): ClientSideCache<User> {
+    fun customizeUserClientSideCache(): ComputedClientSideCache<User> {
         return mockk()
     }
 

--- a/cocache-spring-redis/src/test/kotlin/me/ahoo/cache/spring/redis/RedisMultipleInstanceSyncTest.kt
+++ b/cocache-spring-redis/src/test/kotlin/me/ahoo/cache/spring/redis/RedisMultipleInstanceSyncTest.kt
@@ -13,7 +13,7 @@
 
 package me.ahoo.cache.spring.redis
 
-import me.ahoo.cache.client.ClientSideCache
+import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.client.MapClientSideCache
 import me.ahoo.cache.consistency.CacheEvictedEventBus
 import me.ahoo.cache.converter.KeyConverter

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/client/SpringClientSideCacheFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/client/SpringClientSideCacheFactory.kt
@@ -14,7 +14,7 @@
 package me.ahoo.cache.spring.client
 
 import me.ahoo.cache.annotation.CoCacheMetadata
-import me.ahoo.cache.client.ClientSideCache
+import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.client.ClientSideCacheFactory
 import me.ahoo.cache.client.MapClientSideCacheFactory
 import org.springframework.beans.factory.BeanFactory

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/ClientSideCacheSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/ClientSideCacheSpec.kt
@@ -13,7 +13,7 @@
 
 package me.ahoo.cache.test
 
-import me.ahoo.cache.client.ClientSideCache
+import me.ahoo.cache.api.client.ClientSideCache
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/CoherentCacheSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/CoherentCacheSpec.kt
@@ -17,8 +17,8 @@ import me.ahoo.cache.CoherentCache
 import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.api.Cache
 import me.ahoo.cache.api.CacheValue
+import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.api.source.CacheSource
-import me.ahoo.cache.client.ClientSideCache
 import me.ahoo.cache.consistency.CacheEvictedEvent
 import me.ahoo.cache.consistency.CacheEvictedEventBus
 import me.ahoo.cache.converter.KeyConverter

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/MultipleInstanceSyncSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/MultipleInstanceSyncSpec.kt
@@ -16,7 +16,7 @@ package me.ahoo.cache.test
 import me.ahoo.cache.CacheConfig
 import me.ahoo.cache.CacheManager
 import me.ahoo.cache.CoherentCache
-import me.ahoo.cache.client.ClientSideCache
+import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.consistency.CacheEvictedEvent
 import me.ahoo.cache.consistency.CacheEvictedEventBus
 import me.ahoo.cache.consistency.CacheEvictedSubscriber


### PR DESCRIPTION


- Move ClientSideCache interface from cocache-core to cocache-api module
- Rename interface to ComputedClientSideCache in cocache-core
- Update related classes and tests to use new interface
- Maintain backward compatibility by keeping ClientSideCache in API module