### PR TITLE
feat(cache-proxy): add DistributedClientId support for cache proxy

### DIFF
--- a/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactory.kt
@@ -27,6 +27,7 @@ import me.ahoo.cache.converter.KeyConverter
 import me.ahoo.cache.converter.ToStringKeyConverter
 import me.ahoo.cache.distributed.DistributedCache
 import me.ahoo.cache.distributed.DistributedCacheFactory
+import me.ahoo.cache.distributed.DistributedClientId
 import me.ahoo.cache.source.CacheSourceFactory
 import me.ahoo.cache.util.ClientIdGenerator
 import java.lang.reflect.Proxy
@@ -62,7 +63,8 @@ class DefaultCacheProxyFactory(
                 cacheMetadata.type.java,
                 ComputedCache::class.java,
                 NamedCache::class.java,
-                CacheDelegated::class.java
+                CacheDelegated::class.java,
+                DistributedClientId::class.java
             ),
             invocationHandler
         ) as CACHE

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactoryTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactoryTest.kt
@@ -46,6 +46,7 @@ class DefaultCacheProxyFactoryTest {
         assertNull(cache.getCache("key"))
         assertTrue(cache.toString().startsWith(CoherentCache::class.java.name))
         assertEquals(cache.delegate.cacheName, MockCache::class.java.simpleName)
+        assertEquals(cache.clientId, cache.delegate.clientId)
     }
 
     @Test

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/MockCache.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/MockCache.kt
@@ -16,9 +16,10 @@ package me.ahoo.cache.proxy
 import me.ahoo.cache.CoherentCache
 import me.ahoo.cache.ComputedCache
 import me.ahoo.cache.api.annotation.CoCache
+import me.ahoo.cache.distributed.DistributedClientId
 
 @CoCache
-interface MockCache : ComputedCache<String, String>, CacheDelegated<CoherentCache<String, String>>
+interface MockCache : ComputedCache<String, String>, CacheDelegated<CoherentCache<String, String>>, DistributedClientId
 
 @CoCache(keyPrefix = "prefix:", keyExpression = "#{#root}")
 interface MockCacheWithKeyExpression : ComputedCache<String, String>


### PR DESCRIPTION
- Add DistributedClientId class to the cache proxy interfaces
- Update DefaultCacheProxyFactory to support DistributedClientId
- Modify tests to verify DistributedClientId functionality
