### PR TITLE
feat(core): add CacheMetadataCapable support

### DIFF
--- a/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/CacheMetadataCapable.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/CacheMetadataCapable.kt
@@ -13,17 +13,8 @@
 
 package me.ahoo.cache.proxy
 
-import me.ahoo.cache.CoherentCache
-import me.ahoo.cache.ComputedCache
-import me.ahoo.cache.api.annotation.CoCache
-import me.ahoo.cache.distributed.DistributedClientId
+import me.ahoo.cache.annotation.CoCacheMetadata
 
-@CoCache
-interface MockCache :
-    ComputedCache<String, String>,
-    CacheDelegated<CoherentCache<String, String>>,
-    DistributedClientId,
-    CacheMetadataCapable
-
-@CoCache(keyPrefix = "prefix:", keyExpression = "#{#root}")
-interface MockCacheWithKeyExpression : ComputedCache<String, String>
+interface CacheMetadataCapable {
+    val cacheMetadata: CoCacheMetadata
+}

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/CoCacheInvocationHandler.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/CoCacheInvocationHandler.kt
@@ -13,24 +13,33 @@
 
 package me.ahoo.cache.proxy
 
+import me.ahoo.cache.annotation.CoCacheMetadata
 import me.ahoo.cache.api.Cache
 import me.ahoo.cache.api.NamedCache
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 import kotlin.reflect.jvm.javaGetter
 
-class CoCacheInvocationHandler<K, V : Any, DELEGATE>(override val delegate: DELEGATE) :
+class CoCacheInvocationHandler<K, V : Any, DELEGATE>(
+    override val cacheMetadata: CoCacheMetadata,
+    override val delegate: DELEGATE
+) :
     CacheDelegated<DELEGATE>,
+    CacheMetadataCapable,
     InvocationHandler where DELEGATE : Cache<K, V>, DELEGATE : NamedCache {
 
     companion object {
         val DELEGATE_METHOD_SIGN: String = CacheDelegated<*>::delegate.javaGetter!!.name
+        val CACHE_METADATA_METHOD_SIGN: String = CacheMetadataCapable::cacheMetadata.javaGetter!!.name
     }
 
     @Suppress("SpreadOperator", "ReturnCount")
     override fun invoke(proxy: Any, method: Method, args: Array<out Any>?): Any? {
         if (DELEGATE_METHOD_SIGN == method.name) {
             return delegate
+        }
+        if (CACHE_METADATA_METHOD_SIGN == method.name) {
+            return cacheMetadata
         }
         if (args == null) {
             return method.invoke(delegate)

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactory.kt
@@ -56,7 +56,7 @@ class DefaultCacheProxyFactory(
                 cacheSource = cacheSource,
             ),
         )
-        val invocationHandler = CoCacheInvocationHandler(delegate)
+        val invocationHandler = CoCacheInvocationHandler(cacheMetadata = cacheMetadata, delegate = delegate)
         return Proxy.newProxyInstance(
             cacheMetadata.type.java.classLoader,
             arrayOf(
@@ -64,7 +64,8 @@ class DefaultCacheProxyFactory(
                 ComputedCache::class.java,
                 NamedCache::class.java,
                 CacheDelegated::class.java,
-                DistributedClientId::class.java
+                DistributedClientId::class.java,
+                CacheMetadataCapable::class.java
             ),
             invocationHandler
         ) as CACHE

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactoryTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactoryTest.kt
@@ -47,6 +47,7 @@ class DefaultCacheProxyFactoryTest {
         assertTrue(cache.toString().startsWith(CoherentCache::class.java.name))
         assertEquals(cache.delegate.cacheName, MockCache::class.java.simpleName)
         assertEquals(cache.clientId, cache.delegate.clientId)
+        assertEquals(cache.cacheMetadata, coCacheMetadata<MockCache>())
     }
 
     @Test


### PR DESCRIPTION
- Introduce CacheMetadataCapable interface to expose cache metadata
- Update CoCacheInvocationHandler to handle cache metadata retrieval
- Modify DefaultCacheProxyFactory to include CacheMetadataCapable in proxy
- Add unit test for CacheMetadataCapable functionality
- Update MockCache interface to include CacheMetadataCapable
