### PR TITLE
refactor: remove FunctionalInterface annotation from factory interfaces

### DIFF
--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/ClientSideCacheFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/ClientSideCacheFactory.kt
@@ -16,7 +16,6 @@ package me.ahoo.cache.client
 import me.ahoo.cache.annotation.CoCacheMetadata
 import me.ahoo.cache.api.client.ClientSideCache
 
-@FunctionalInterface
 interface ClientSideCacheFactory {
     fun <V> create(cacheMetadata: CoCacheMetadata): ClientSideCache<V>
 }

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/distributed/DistributedCacheFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/distributed/DistributedCacheFactory.kt
@@ -15,7 +15,6 @@ package me.ahoo.cache.distributed
 
 import me.ahoo.cache.annotation.CoCacheMetadata
 
-@FunctionalInterface
 interface DistributedCacheFactory {
     fun <V> create(cacheMetadata: CoCacheMetadata): DistributedCache<V>
 }

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/source/CacheSourceFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/source/CacheSourceFactory.kt
@@ -16,7 +16,6 @@ package me.ahoo.cache.source
 import me.ahoo.cache.annotation.CoCacheMetadata
 import me.ahoo.cache.api.source.CacheSource
 
-@FunctionalInterface
 interface CacheSourceFactory {
     fun <K, V> create(cacheMetadata: CoCacheMetadata): CacheSource<K, V>
 }


### PR DESCRIPTION
- Removed @FunctionalInterface annotation from CacheSourceFactory, ClientSideCacheFactory, and DistributedCacheFactory interfaces
- This change simplifies the interface definitions and removes redundant annotations, as the interfaces are already inferred to be functional interfaces by the Kotlin compiler
