### PR TITLE
refactor(cocache-core): improve type safety and remove unnecessary checks

### DIFF
--- a/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParser.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParser.kt
@@ -18,7 +18,6 @@ import me.ahoo.cache.api.Cache
 import me.ahoo.cache.api.annotation.CoCache
 import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotation
-import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.jvm.jvmName
 
 object CoCacheMetadataParser {
@@ -27,12 +26,9 @@ object CoCacheMetadataParser {
      *
      * @param cacheType 必须继承 `Cache` 接口，必须有 `@CoCache` 注解 ,必须是接口
      */
-    fun parse(cacheType: KClass<*>): CoCacheMetadata {
+    fun parse(cacheType: KClass<out Cache<*, *>>): CoCacheMetadata {
         require(cacheType.java.isInterface) {
             "${cacheType.jvmName} must be interface."
-        }
-        require(cacheType.isSubclassOf(Cache::class)) {
-            "cacheType must inherit from Cache<K,V> interface"
         }
         val coCacheAnnotation = requireNotNull(cacheType.findAnnotation<CoCache>()) {
             "cacheType must be annotated with @CoCache"
@@ -58,10 +54,10 @@ object CoCacheMetadataParser {
     }
 }
 
-fun KClass<*>.toCoCacheMetadata(): CoCacheMetadata {
+fun KClass<out Cache<*, *>>.toCoCacheMetadata(): CoCacheMetadata {
     return CoCacheMetadataParser.parse(this)
 }
 
-inline fun <reified C> coCacheMetadata(): CoCacheMetadata {
-    return C::class.toCoCacheMetadata()
+inline fun <reified CACHE : Cache<*, *>> coCacheMetadata(): CoCacheMetadata {
+    return CACHE::class.toCoCacheMetadata()
 }

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParserTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParserTest.kt
@@ -39,13 +39,6 @@ class CoCacheMetadataParserTest {
     }
 
     @Test
-    fun parseIfNotSubclassOfCache() {
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
-            coCacheMetadata<NotSubclassOfCache>()
-        }
-    }
-
-    @Test
     fun parseIfNotCacheAnnotation() {
         Assertions.assertThrows(IllegalArgumentException::class.java) {
             coCacheMetadata<NotCacheAnnotation>()
@@ -55,9 +48,7 @@ class CoCacheMetadataParserTest {
     @CoCache
     interface MockCache : Cache<String, CoCacheMetadataParserTest>
 
-    class NotInterface
-
-    interface NotSubclassOfCache
+    abstract class NotInterface : Cache<String, CoCacheMetadataParserTest>
 
     interface NotCacheAnnotation : ComputedCache<String, CoCacheMetadataParserTest>
 }

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/EnableCoCacheRegistrar.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/EnableCoCacheRegistrar.kt
@@ -15,6 +15,7 @@ package me.ahoo.cache.spring
 
 import me.ahoo.cache.annotation.CoCacheMetadata
 import me.ahoo.cache.annotation.toCoCacheMetadata
+import me.ahoo.cache.api.Cache
 import me.ahoo.cache.spring.proxy.CacheProxyFactoryBean
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.support.BeanDefinitionBuilder
@@ -44,7 +45,7 @@ class EnableCoCacheRegistrar : ImportBeanDefinitionRegistrar {
     private fun resolveCacheMetadataList(importingClassMetadata: AnnotationMetadata): List<CoCacheMetadata> {
         val enableCoCache = importingClassMetadata
             .getAnnotationAttributes(EnableCoCache::class.java.name) ?: return emptyList()
-        val caches = enableCoCache[EnableCoCache::caches.name] as Array<Class<*>>
+        val caches = enableCoCache[EnableCoCache::caches.name] as Array<Class<Cache<*, *>>>
         return caches.map { it.kotlin.toCoCacheMetadata() }
     }
 }

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/source/SpringCacheSourceFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/source/SpringCacheSourceFactory.kt
@@ -25,14 +25,13 @@ class SpringCacheSourceFactory(private val beanFactory: BeanFactory) : CacheSour
         private val log = LoggerFactory.getLogger(SpringCacheSourceFactory::class.java)
     }
 
-    @Suppress("UNCHECKED_CAST")
     override fun <K, V> create(cacheMetadata: CoCacheMetadata): CacheSource<K, V> {
         val cacheSourceType = ResolvableType.forClassWithGenerics(
             CacheSource::class.java,
             cacheMetadata.keyType.java,
             cacheMetadata.valueType.java
         )
-        val cacheSourceProvider = beanFactory.getBeanProvider<CacheSource<String, Any>>(cacheSourceType)
+        val cacheSourceProvider = beanFactory.getBeanProvider<CacheSource<K, V>>(cacheSourceType)
         return cacheSourceProvider.getIfAvailable {
             if (log.isWarnEnabled) {
                 log.warn(
@@ -41,6 +40,6 @@ class SpringCacheSourceFactory(private val beanFactory: BeanFactory) : CacheSour
                 )
             }
             CacheSource.noOp()
-        } as CacheSource<K, V>
+        }
     }
 }


### PR DESCRIPTION
- Update `parse` function to use KClass<out Cache<*, *>> instead of KClass<*>
- Remove redundant subclass check since it's enforced by the type system
- Update related test cases and classes to reflect the new type constraints
- Improve type safety in Spring-related classes by using specific Cache types
