### PR TITLE
feat(cache): enhance GuavaCache with expireUnit and MissingGuardCache

### DIFF
--- a/cocache-api/src/main/kotlin/me/ahoo/cache/api/annotation/GuavaCache.kt
+++ b/cocache-api/src/main/kotlin/me/ahoo/cache/api/annotation/GuavaCache.kt
@@ -14,6 +14,7 @@
 package me.ahoo.cache.api.annotation
 
 import java.lang.annotation.Inherited
+import java.util.concurrent.TimeUnit
 
 /**
  * @see me.ahoo.cache.api.client.ClientSideCache
@@ -26,8 +27,9 @@ annotation class GuavaCache(
     val initialCapacity: Int = UNSET_INT,
     val concurrencyLevel: Int = UNSET_INT,
     val maximumSize: Long = UNSET_LONG,
-    val expireAfterWriteNanos: Long = UNSET_LONG,
-    val expireAfterAccessNanos: Long = UNSET_LONG
+    val expireUnit: TimeUnit = TimeUnit.SECONDS,
+    val expireAfterWrite: Long = UNSET_LONG,
+    val expireAfterAccess: Long = UNSET_LONG
 ) {
     companion object {
         const val UNSET_INT: Int = -1

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/DefaultClientSideCacheFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/DefaultClientSideCacheFactory.kt
@@ -32,11 +32,11 @@ object DefaultClientSideCacheFactory : ClientSideCacheFactory {
         if (guavaCache.maximumSize != GuavaCache.UNSET_LONG) {
             cacheBuilder.maximumSize(guavaCache.maximumSize)
         }
-        if (guavaCache.expireAfterWriteNanos != GuavaCache.UNSET_LONG) {
-            cacheBuilder.expireAfterWrite(guavaCache.expireAfterWriteNanos, java.util.concurrent.TimeUnit.NANOSECONDS)
+        if (guavaCache.expireAfterWrite != GuavaCache.UNSET_LONG) {
+            cacheBuilder.expireAfterWrite(guavaCache.expireAfterWrite, guavaCache.expireUnit)
         }
-        if (guavaCache.expireAfterAccessNanos != GuavaCache.UNSET_LONG) {
-            cacheBuilder.expireAfterAccess(guavaCache.expireAfterAccessNanos, java.util.concurrent.TimeUnit.NANOSECONDS)
+        if (guavaCache.expireAfterAccess != GuavaCache.UNSET_LONG) {
+            cacheBuilder.expireAfterAccess(guavaCache.expireAfterAccess, guavaCache.expireUnit)
         }
         return GuavaClientSideCache(cacheBuilder.build())
     }

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/client/MockCache.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/client/MockCache.kt
@@ -16,6 +16,7 @@ package me.ahoo.cache.client
 import me.ahoo.cache.ComputedCache
 import me.ahoo.cache.api.annotation.CoCache
 import me.ahoo.cache.api.annotation.GuavaCache
+import java.util.concurrent.TimeUnit
 
 @CoCache
 @GuavaCache
@@ -26,7 +27,8 @@ interface MockDefaultGuavaClientCache : ComputedCache<String, String>
     initialCapacity = 1,
     maximumSize = 2,
     concurrencyLevel = 3,
-    expireAfterAccessNanos = 4,
-    expireAfterWriteNanos = 5
+    expireUnit = TimeUnit.SECONDS,
+    expireAfterAccess = 4,
+    expireAfterWrite = 5
 )
 interface MockCustomizeGuavaClientCache : ComputedCache<String, String>

--- a/cocache-example/src/main/kotlin/me/ahoo/cache/example/cache/UserCache.kt
+++ b/cocache-example/src/main/kotlin/me/ahoo/cache/example/cache/UserCache.kt
@@ -15,7 +15,16 @@ package me.ahoo.cache.example.cache
 
 import me.ahoo.cache.api.Cache
 import me.ahoo.cache.api.annotation.CoCache
+import me.ahoo.cache.api.annotation.GuavaCache
+import me.ahoo.cache.api.annotation.MissingGuardCache
 import me.ahoo.cache.example.model.User
+import java.util.concurrent.TimeUnit
 
 @CoCache
+@GuavaCache(
+    maximumSize = 1000_000,
+    expireUnit = TimeUnit.SECONDS,
+    expireAfterAccess = 120
+)
+@MissingGuardCache(ttlSeconds = 120)
 interface UserCache : Cache<String, User>


### PR DESCRIPTION
- Add expireUnit to GuavaCache annotation for more flexible expiration settings
- Implement support for expireAfterWrite and expireAfterAccess with custom time units
- Add MissingGuardCache annotation to handle missing cache entries
- Update UserCache example to demonstrate new caching features
