### PR TITLE
refactor(spring): introduce AbstractCacheFactory for common cache creation logic

### DIFF
--- a/cocache-spring-redis/build.gradle.kts
+++ b/cocache-spring-redis/build.gradle.kts
@@ -1,5 +1,6 @@
 dependencies {
     api(project(":cocache-core"))
+    api(project(":cocache-spring"))
     api("com.fasterxml.jackson.core:jackson-databind")
     api("org.springframework.data:spring-data-redis")
     testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/AbstractCacheFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/AbstractCacheFactory.kt
@@ -43,7 +43,7 @@ abstract class AbstractCacheFactory(private val beanFactory: BeanFactory) {
         return provider.getIfAvailable {
             if (log.isWarnEnabled) {
                 log.warn(
-                    "[${this.javaClass.simpleName} ] Not found for {}, fallback.",
+                    "[${this.javaClass.simpleName}] Not found for {}, fallback.",
                     cacheMetadata
                 )
             }

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/AbstractCacheFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/AbstractCacheFactory.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cache.spring
+
+import me.ahoo.cache.annotation.CoCacheMetadata
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.core.ResolvableType
+
+abstract class AbstractCacheFactory(private val beanFactory: BeanFactory) {
+
+    companion object {
+        private val log = org.slf4j.LoggerFactory.getLogger(AbstractCacheFactory::class.java)
+    }
+
+    abstract val suffix: String
+
+    private fun getBeanName(cacheMetadata: CoCacheMetadata): String {
+        return cacheMetadata.cacheName + suffix
+    }
+
+    abstract fun getBeanType(cacheMetadata: CoCacheMetadata): ResolvableType
+
+    abstract fun fallback(cacheMetadata: CoCacheMetadata): Any
+
+    fun createBean(cacheMetadata: CoCacheMetadata): Any {
+        val beanName = getBeanName(cacheMetadata)
+        if (beanFactory.containsBean(beanName)) {
+            return beanFactory.getBean(beanName)
+        }
+        val beanType = getBeanType(cacheMetadata)
+        val provider = beanFactory.getBeanProvider<Any>(beanType)
+        return provider.getIfAvailable {
+            if (log.isWarnEnabled) {
+                log.warn(
+                    "[${this.javaClass.simpleName} ] Not found for {}, fallback.",
+                    cacheMetadata
+                )
+            }
+            fallback(cacheMetadata)
+        }
+    }
+}


### PR DESCRIPTION
- Add AbstractCacheFactory to encapsulate common cache creation logic
- Refactor RedisDistributedCacheFactory, SpringCacheSourceFactory, and SpringClientSideCacheFactory to extend AbstractCacheFactory
- Update build.gradle.kts to include cocache-spring as a dependency
- Simplify cache creation in specific factory classes