### PR TITLE
refactor(keyConverter): introduce KeyConverterFactory for better key conversion management

### DIFF
--- a/cocache-core/src/main/kotlin/me/ahoo/cache/converter/DefaultKeyConverterFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/converter/DefaultKeyConverterFactory.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cache.converter
+
+import me.ahoo.cache.annotation.CoCacheMetadata
+import me.ahoo.cache.api.annotation.CoCache
+
+object DefaultKeyConverterFactory : KeyConverterFactory {
+    override fun <K> create(cacheMetadata: CoCacheMetadata): KeyConverter<K> {
+        val cacheKeyPrefix = cacheMetadata.keyPrefix.ifBlank {
+            "${CoCache.COCACHE}:${cacheMetadata.cacheName}:"
+        }
+        if (cacheMetadata.keyExpression.isNotBlank()) {
+            return ExpKeyConverter(cacheKeyPrefix, cacheMetadata.keyExpression)
+        }
+        return ToStringKeyConverter(cacheKeyPrefix)
+    }
+}

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/converter/KeyConverterFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/converter/KeyConverterFactory.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cache.converter
+
+import me.ahoo.cache.annotation.CoCacheMetadata
+
+interface KeyConverterFactory {
+    fun <K> create(cacheMetadata: CoCacheMetadata): KeyConverter<K>
+}

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactoryTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactoryTest.kt
@@ -7,6 +7,7 @@ import me.ahoo.cache.annotation.coCacheMetadata
 import me.ahoo.cache.api.source.CacheSource
 import me.ahoo.cache.client.DefaultClientSideCacheFactory
 import me.ahoo.cache.consistency.NoOpCacheEvictedEventBus
+import me.ahoo.cache.converter.DefaultKeyConverterFactory
 import me.ahoo.cache.distributed.DistributedCache
 import me.ahoo.cache.distributed.DistributedCacheFactory
 import me.ahoo.cache.distributed.mock.MockDistributedCache
@@ -34,7 +35,8 @@ class DefaultCacheProxyFactoryTest {
                 clientIdGenerator = ClientIdGenerator.UUID,
                 clientSideCacheFactory = DefaultClientSideCacheFactory,
                 distributedCacheFactory = distributedCacheFactory,
-                cacheSourceFactory = cacheSourceFactory
+                cacheSourceFactory = cacheSourceFactory,
+                keyConverterFactory = DefaultKeyConverterFactory
             )
             return cacheProxyFactory.create(metadata)
         }

--- a/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfiguration.kt
+++ b/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfiguration.kt
@@ -15,6 +15,8 @@ package me.ahoo.cache.spring.boot.starter
 import me.ahoo.cache.CacheManager
 import me.ahoo.cache.client.ClientSideCacheFactory
 import me.ahoo.cache.consistency.CacheEvictedEventBus
+import me.ahoo.cache.converter.DefaultKeyConverterFactory
+import me.ahoo.cache.converter.KeyConverterFactory
 import me.ahoo.cache.distributed.DistributedCacheFactory
 import me.ahoo.cache.proxy.CacheProxyFactory
 import me.ahoo.cache.proxy.DefaultCacheProxyFactory
@@ -104,19 +106,28 @@ class CoCacheAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    fun keyConverterFactory(): KeyConverterFactory {
+        return DefaultKeyConverterFactory
+    }
+
+    @Suppress("LongParameterList")
+    @Bean
+    @ConditionalOnMissingBean
     fun cacheProxyFactory(
         cacheManager: CacheManager,
         clientIdGenerator: ClientIdGenerator,
         clientSideCacheFactory: ClientSideCacheFactory,
         distributedCacheFactory: DistributedCacheFactory,
-        cacheSourceResolver: CacheSourceFactory
+        cacheSourceResolver: CacheSourceFactory,
+        keyConverterFactory: KeyConverterFactory
     ): CacheProxyFactory {
         return DefaultCacheProxyFactory(
             cacheManager,
             clientIdGenerator,
             clientSideCacheFactory,
             distributedCacheFactory,
-            cacheSourceResolver
+            cacheSourceResolver,
+            keyConverterFactory
         )
     }
 


### PR DESCRIPTION
- Add KeyConverterFactory interface and DefaultKeyConverterFactory implementation
- Move key converter creation logic out of DefaultCacheProxyFactory
- Update CoCacheAutoConfiguration to include keyConverterFactory bean
- Modify tests to use new keyConverterFactory
