### PR TITLE
refactor(spring): resolve key converter with spring context

### DIFF
--- a/cocache-example/src/main/kotlin/me/ahoo/cache/example/cache/UserCache.kt
+++ b/cocache-example/src/main/kotlin/me/ahoo/cache/example/cache/UserCache.kt
@@ -20,7 +20,7 @@ import me.ahoo.cache.api.annotation.MissingGuardCache
 import me.ahoo.cache.example.model.User
 import java.util.concurrent.TimeUnit
 
-@CoCache
+@CoCache(keyPrefix = "user:")
 @GuavaCache(
     maximumSize = 1000_000,
     expireUnit = TimeUnit.SECONDS,

--- a/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfiguration.kt
+++ b/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfiguration.kt
@@ -15,13 +15,13 @@ package me.ahoo.cache.spring.boot.starter
 import me.ahoo.cache.CacheManager
 import me.ahoo.cache.client.ClientSideCacheFactory
 import me.ahoo.cache.consistency.CacheEvictedEventBus
-import me.ahoo.cache.converter.DefaultKeyConverterFactory
 import me.ahoo.cache.converter.KeyConverterFactory
 import me.ahoo.cache.distributed.DistributedCacheFactory
 import me.ahoo.cache.proxy.CacheProxyFactory
 import me.ahoo.cache.proxy.DefaultCacheProxyFactory
 import me.ahoo.cache.source.CacheSourceFactory
 import me.ahoo.cache.spring.client.SpringClientSideCacheFactory
+import me.ahoo.cache.spring.converter.SpringKeyConverterFactory
 import me.ahoo.cache.spring.redis.RedisCacheEvictedEventBus
 import me.ahoo.cache.spring.redis.RedisDistributedCacheFactory
 import me.ahoo.cache.spring.source.SpringCacheSourceFactory
@@ -36,6 +36,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.RedisConnectionFactory
@@ -106,8 +107,8 @@ class CoCacheAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun keyConverterFactory(): KeyConverterFactory {
-        return DefaultKeyConverterFactory
+    fun keyConverterFactory(appContext: ApplicationContext): KeyConverterFactory {
+        return SpringKeyConverterFactory(appContext)
     }
 
     @Suppress("LongParameterList")

--- a/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfigurationTest.kt
+++ b/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfigurationTest.kt
@@ -18,6 +18,8 @@ import me.ahoo.cache.consistency.CacheEvictedEventBus
 import me.ahoo.cache.example.cache.UserCache
 import me.ahoo.cache.spring.boot.starter.auto.EnableCoCacheConfiguration
 import me.ahoo.cache.spring.boot.starter.customize.EnableCoCacheConfigurationWithCustomize
+import me.ahoo.cache.spring.boot.starter.customize.UserExpCache
+import me.ahoo.cache.spring.boot.starter.customize.UserPlaceholderCache
 import me.ahoo.cache.util.ClientIdGenerator
 import me.ahoo.cosid.machine.HostAddressSupplier
 import me.ahoo.cosid.machine.LocalHostAddressSupplier
@@ -53,6 +55,7 @@ internal class CoCacheAutoConfigurationTest {
     @Test
     fun contextLoadsWithCustomize() {
         contextRunner
+            .withPropertyValues("spring.application.name=cocache-example")
             .withUserConfiguration(
                 RedisAutoConfiguration::class.java,
                 CoCacheAutoConfiguration::class.java,
@@ -67,6 +70,8 @@ internal class CoCacheAutoConfigurationTest {
                     .hasSingleBean(UserCache::class.java)
 
                 context.getBean(UserCache::class.java)
+                context.getBean(UserExpCache::class.java)
+                context.getBean(UserPlaceholderCache::class.java)
             }
     }
 

--- a/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/customize/EnableCoCacheConfigurationWithCustomize.kt
+++ b/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/customize/EnableCoCacheConfigurationWithCustomize.kt
@@ -51,7 +51,7 @@ class EnableCoCacheConfigurationWithCustomize {
     }
 }
 
-@CoCache(keyPrefix = "user:", keyExpression = "#{#root}")
+@CoCache(keyExpression = "#{#root}")
 interface UserExpCache : Cache<String, User>
 
 @CoCache(keyPrefix = "\${spring.application.name}:user")

--- a/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/customize/EnableCoCacheConfigurationWithCustomize.kt
+++ b/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/customize/EnableCoCacheConfigurationWithCustomize.kt
@@ -14,6 +14,8 @@
 package me.ahoo.cache.spring.boot.starter.customize
 
 import io.mockk.mockk
+import me.ahoo.cache.api.Cache
+import me.ahoo.cache.api.annotation.CoCache
 import me.ahoo.cache.api.source.CacheSource
 import me.ahoo.cache.client.ComputedClientSideCache
 import me.ahoo.cache.distributed.DistributedCache
@@ -26,7 +28,9 @@ import org.springframework.context.annotation.Bean
 @SpringBootApplication
 @EnableCoCache(
     caches = [
-        UserCache::class
+        UserCache::class,
+        UserExpCache::class,
+        UserPlaceholderCache::class
     ]
 )
 class EnableCoCacheConfigurationWithCustomize {
@@ -46,3 +50,9 @@ class EnableCoCacheConfigurationWithCustomize {
         return mockk()
     }
 }
+
+@CoCache(keyPrefix = "user:", keyExpression = "#{#root}")
+interface UserExpCache : Cache<String, User>
+
+@CoCache(keyPrefix = "\${spring.application.name}:user")
+interface UserPlaceholderCache : Cache<String, User>

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/converter/SpringKeyConverterFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/converter/SpringKeyConverterFactory.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cache.spring.converter
+
+import me.ahoo.cache.annotation.CoCacheMetadata
+import me.ahoo.cache.api.annotation.CoCache
+import me.ahoo.cache.converter.ExpKeyConverter
+import me.ahoo.cache.converter.KeyConverter
+import me.ahoo.cache.converter.KeyConverterFactory
+import me.ahoo.cache.converter.ToStringKeyConverter
+import me.ahoo.cache.spring.AbstractCacheFactory
+import org.springframework.context.ApplicationContext
+import org.springframework.core.ResolvableType
+
+class SpringKeyConverterFactory(private val appContext: ApplicationContext) : KeyConverterFactory,
+    AbstractCacheFactory(appContext) {
+
+    companion object {
+        const val KEY_CONVERTER_SUFFIX = ".KeyConverter"
+    }
+
+    override val suffix: String = KEY_CONVERTER_SUFFIX
+
+    override fun getBeanType(cacheMetadata: CoCacheMetadata): ResolvableType {
+        return ResolvableType.forClassWithGenerics(
+            KeyConverter::class.java,
+            cacheMetadata.keyType.java
+        )
+    }
+
+    override fun fallback(cacheMetadata: CoCacheMetadata): Any {
+        val cacheKeyPrefix = if (cacheMetadata.keyPrefix.isNotBlank()) {
+            appContext.environment.resolvePlaceholders(cacheMetadata.keyPrefix)
+        } else {
+            "${CoCache.COCACHE}:${cacheMetadata.cacheName}:"
+        }
+
+        if (cacheMetadata.keyExpression.isNotBlank()) {
+            val keyExp = appContext.environment.resolvePlaceholders(cacheMetadata.keyExpression)
+            return ExpKeyConverter<Any>(cacheKeyPrefix, keyExp)
+        }
+        return ToStringKeyConverter<Any>(cacheKeyPrefix)
+    }
+
+    override fun <K> create(cacheMetadata: CoCacheMetadata): KeyConverter<K> {
+        @Suppress("UNCHECKED_CAST")
+        return createBean(cacheMetadata) as KeyConverter<K>
+    }
+}

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/proxy/CacheProxyFactoryBean.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/proxy/CacheProxyFactoryBean.kt
@@ -30,17 +30,10 @@ class CacheProxyFactoryBean(private val cacheMetadata: CoCacheMetadata) :
 
     override fun getObject(): Cache<Any, Any> {
         val cacheProxyFactory = appContext.getBean(CacheProxyFactory::class.java)
-        val resolvedMetadata = resolveMetadata()
-        return cacheProxyFactory.create(resolvedMetadata)
+        return cacheProxyFactory.create(cacheMetadata)
     }
 
     override fun getObjectType(): Class<*> {
         return cacheMetadata.type.java
-    }
-
-    private fun resolveMetadata(): CoCacheMetadata {
-        val keyPrefix = appContext.environment.resolvePlaceholders(cacheMetadata.keyPrefix)
-        val keyExpression = appContext.environment.resolvePlaceholders(cacheMetadata.keyExpression)
-        return cacheMetadata.copy(keyPrefix = keyPrefix, keyExpression = keyExpression)
     }
 }


### PR DESCRIPTION
- Remove resolveMetadata function from CacheProxyFactoryBean
- Create SpringKeyConverterFactory to handle key conversion in Spring context
- Update CoCacheAutoConfiguration to use SpringKeyConverterFactory