### PR TITLE
refactor(spring): introduce getBeanProvider for more flexible bean creation

### DIFF
--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/converter/SpringKeyConverterFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/converter/SpringKeyConverterFactory.kt
@@ -39,6 +39,10 @@ class SpringKeyConverterFactory(private val appContext: ApplicationContext) : Ke
         )
     }
 
+    override fun getBeanProvider(cacheMetadata: CoCacheMetadata, fallback: () -> Any): Any {
+        return fallback()
+    }
+
     override fun fallback(cacheMetadata: CoCacheMetadata): Any {
         val cacheKeyPrefix = if (cacheMetadata.keyPrefix.isNotBlank()) {
             appContext.environment.resolvePlaceholders(cacheMetadata.keyPrefix)


### PR DESCRIPTION
- Add getBeanProvider method to AbstractCacheFactory
- Implement getBeanProvider in SpringKeyConverterFactory
- Update createBean method to use getBeanProvider
- Improve code structure and reduce duplication
