### PR TITLE
feat(annotation): make @CoCache optional for cache interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ UserCacheSource  ..>  CacheSource~K, V~
 ```kotlin
 
 /**
- * 定义缓存接口,必须的
+ * 定义缓存接口
+ * 可选的配置
  */
 @CoCache
 /**

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParser.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParser.kt
@@ -24,16 +24,13 @@ object CoCacheMetadataParser {
     /**
      * 解析 CoCache 注解定义的 Cache 接口
      *
-     * @param cacheType 必须继承 `Cache` 接口，必须有 `@CoCache` 注解 ,必须是接口
+     * @param cacheType 必须继承 `Cache` 接口，必须是接口
      */
     fun parse(cacheType: KClass<out Cache<*, *>>): CoCacheMetadata {
         require(cacheType.java.isInterface) {
             "${cacheType.jvmName} must be interface."
         }
-        val coCacheAnnotation = requireNotNull(cacheType.findAnnotation<CoCache>()) {
-            "cacheType must be annotated with @CoCache"
-        }
-
+        val coCacheAnnotation = cacheType.findAnnotation<CoCache>() ?: CoCache()
         // 获取继承的 Cache<K,V> 中 V 的具体类型
         val superCacheType = cacheType.supertypes.first {
             it.classifier == Cache::class || it.classifier == ComputedCache::class

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParserTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParserTest.kt
@@ -1,11 +1,10 @@
 package me.ahoo.cache.annotation
 
-import me.ahoo.cache.ComputedCache
 import me.ahoo.cache.api.Cache
 import me.ahoo.cache.api.annotation.CoCache
 import me.ahoo.cache.proxy.MockCacheWithKeyExpression
 import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.MatcherAssert.*
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -38,17 +37,8 @@ class CoCacheMetadataParserTest {
         }
     }
 
-    @Test
-    fun parseIfNotCacheAnnotation() {
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
-            coCacheMetadata<NotCacheAnnotation>()
-        }
-    }
-
     @CoCache
     interface MockCache : Cache<String, CoCacheMetadataParserTest>
 
     abstract class NotInterface : Cache<String, CoCacheMetadataParserTest>
-
-    interface NotCacheAnnotation : ComputedCache<String, CoCacheMetadataParserTest>
 }

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParserTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParserTest.kt
@@ -1,5 +1,6 @@
 package me.ahoo.cache.annotation
 
+import me.ahoo.cache.ComputedCache
 import me.ahoo.cache.api.Cache
 import me.ahoo.cache.api.annotation.CoCache
 import me.ahoo.cache.proxy.MockCacheWithKeyExpression
@@ -14,6 +15,16 @@ class CoCacheMetadataParserTest {
     fun parse() {
         val metadata = coCacheMetadata<MockCache>()
         assertThat(metadata.type, equalTo(MockCache::class))
+        assertThat(metadata.name, equalTo(""))
+        assertThat(metadata.keyPrefix, equalTo(""))
+        assertThat(metadata.keyType, equalTo(String::class))
+        assertThat(metadata.valueType, equalTo(CoCacheMetadataParserTest::class))
+    }
+
+    @Test
+    fun parseComputedCache() {
+        val metadata = coCacheMetadata<MockComputedCache>()
+        assertThat(metadata.type, equalTo(MockComputedCache::class))
         assertThat(metadata.name, equalTo(""))
         assertThat(metadata.keyPrefix, equalTo(""))
         assertThat(metadata.keyType, equalTo(String::class))
@@ -40,5 +51,7 @@ class CoCacheMetadataParserTest {
     @CoCache
     interface MockCache : Cache<String, CoCacheMetadataParserTest>
 
+    @CoCache
+    interface MockComputedCache : ComputedCache<String, CoCacheMetadataParserTest>
     abstract class NotInterface : Cache<String, CoCacheMetadataParserTest>
 }


### PR DESCRIPTION
- Remove the requirement for cache interfaces to be annotated with @CoCache
- Update CoCacheMetadataParser to handle interfaces without @CoCache annotation
- Adjust tests to remove explicit @CoCache annotation checks
- Update README to reflect that @CoCache annotation is now optional
