### PR TITLE
refactor(cocache-core): move GuavaCache configuration to companion object

### DIFF
--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/DefaultClientSideCacheFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/DefaultClientSideCacheFactory.kt
@@ -13,36 +13,15 @@
 
 package me.ahoo.cache.client
 
-import com.google.common.cache.CacheBuilder
 import me.ahoo.cache.annotation.CoCacheMetadata
 import me.ahoo.cache.api.annotation.GuavaCache
 import me.ahoo.cache.api.client.ClientSideCache
+import me.ahoo.cache.client.GuavaClientSideCache.Companion.toClientSideCache
 import kotlin.reflect.full.findAnnotation
 
 object DefaultClientSideCacheFactory : ClientSideCacheFactory {
     override fun <V> create(cacheMetadata: CoCacheMetadata): ClientSideCache<V> {
         val guavaCache = cacheMetadata.type.findAnnotation<GuavaCache>() ?: return MapClientSideCache()
-        val cacheBuilder = cacheBuilder(guavaCache)
-        return GuavaClientSideCache(cacheBuilder.build())
-    }
-
-    fun cacheBuilder(guavaCache: GuavaCache): CacheBuilder<Any, Any> {
-        val cacheBuilder = CacheBuilder.newBuilder()
-        if (guavaCache.initialCapacity != GuavaCache.UNSET_INT) {
-            cacheBuilder.initialCapacity(guavaCache.initialCapacity)
-        }
-        if (guavaCache.concurrencyLevel != GuavaCache.UNSET_INT) {
-            cacheBuilder.concurrencyLevel(guavaCache.concurrencyLevel)
-        }
-        if (guavaCache.maximumSize != GuavaCache.UNSET_LONG) {
-            cacheBuilder.maximumSize(guavaCache.maximumSize)
-        }
-        if (guavaCache.expireAfterWrite != GuavaCache.UNSET_LONG) {
-            cacheBuilder.expireAfterWrite(guavaCache.expireAfterWrite, guavaCache.expireUnit)
-        }
-        if (guavaCache.expireAfterAccess != GuavaCache.UNSET_LONG) {
-            cacheBuilder.expireAfterAccess(guavaCache.expireAfterAccess, guavaCache.expireUnit)
-        }
-        return cacheBuilder
+        return guavaCache.toClientSideCache()
     }
 }

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/GuavaClientSideCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/GuavaClientSideCache.kt
@@ -15,6 +15,7 @@ package me.ahoo.cache.client
 import com.google.common.cache.Cache
 import com.google.common.cache.CacheBuilder
 import me.ahoo.cache.api.CacheValue
+import me.ahoo.cache.api.annotation.GuavaCache
 
 /**
  * Guava Client Side Cache .
@@ -45,5 +46,27 @@ class GuavaClientSideCache<V>(
 
     override fun clear() {
         guavaCache.invalidateAll()
+    }
+
+    companion object {
+        fun <V> GuavaCache.toClientSideCache(): GuavaClientSideCache<V> {
+            val cacheBuilder = CacheBuilder.newBuilder()
+            if (initialCapacity != GuavaCache.UNSET_INT) {
+                cacheBuilder.initialCapacity(initialCapacity)
+            }
+            if (concurrencyLevel != GuavaCache.UNSET_INT) {
+                cacheBuilder.concurrencyLevel(concurrencyLevel)
+            }
+            if (maximumSize != GuavaCache.UNSET_LONG) {
+                cacheBuilder.maximumSize(maximumSize)
+            }
+            if (expireAfterWrite != GuavaCache.UNSET_LONG) {
+                cacheBuilder.expireAfterWrite(expireAfterWrite, expireUnit)
+            }
+            if (expireAfterAccess != GuavaCache.UNSET_LONG) {
+                cacheBuilder.expireAfterAccess(expireAfterAccess, expireUnit)
+            }
+            return GuavaClientSideCache(cacheBuilder.build())
+        }
     }
 }


### PR DESCRIPTION
- Extract GuavaCache configuration logic to GuavaClientSideCache companion object
- Simplify DefaultClientSideCacheFactory.create() method
- Improve code reusability and maintainability
