### PR TITLE
refactor(cocache-core): rename SimpleJoinCaching to SimpleJoinCache

### DIFF
--- a/cocache-core/src/main/kotlin/me/ahoo/cache/join/SimpleJoinCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/join/SimpleJoinCache.kt
@@ -23,11 +23,11 @@ import me.ahoo.cache.api.join.JoinValue
 import kotlin.math.min
 
 /**
- * Simple Join Caching .
+ * Simple Join Cache .
  *
  * @author ahoo wang
  */
-class SimpleJoinCaching<K1, V1, K2, V2>(
+class SimpleJoinCache<K1, V1, K2, V2>(
     private val firstCache: Cache<K1, V1>,
     private val joinCache: Cache<K2, V2>,
     override val extractJoinKey: ExtractJoinKey<V1, K2>

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/join/SimpleJoinCacheTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/join/SimpleJoinCacheTest.kt
@@ -23,12 +23,12 @@ import me.ahoo.cosid.jvm.UuidGenerator
  *
  * @author ahoo wang
  */
-internal class SimpleJoinCachingTest : CacheSpec<String, JoinValue<Order, String, OrderAddress>>() {
+internal class SimpleJoinCacheTest : CacheSpec<String, JoinValue<Order, String, OrderAddress>>() {
 
     override fun createCache(): Cache<String, JoinValue<Order, String, OrderAddress>> {
         val orderCache = MapClientSideCache<Order>()
         val orderAddressCache = MapClientSideCache<OrderAddress>()
-        return SimpleJoinCaching(
+        return SimpleJoinCache(
             orderCache,
             orderAddressCache,
         ) { firstValue -> firstValue.id }


### PR DESCRIPTION
- Rename SimpleJoinCaching class to SimpleJoinCache for better clarity and consistency
- Update related test file name from SimpleJoinCachingTest to SimpleJoinCacheTest