### PR TITLE
feat(core): support default method in cache proxy

### DIFF
--- a/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/CacheDelegated.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/CacheDelegated.kt
@@ -14,8 +14,7 @@
 package me.ahoo.cache.proxy
 
 import me.ahoo.cache.api.Cache
-import me.ahoo.cache.api.NamedCache
 
-interface CacheDelegated<DELEGATE> where DELEGATE : Cache<*, *>, DELEGATE : NamedCache {
+interface CacheDelegated<DELEGATE> where DELEGATE : Cache<*, *> {
     val delegate: DELEGATE
 }

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/CoCacheProxy.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/CoCacheProxy.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cache.proxy
+
+import me.ahoo.cache.api.Cache
+import me.ahoo.cache.proxy.CoCacheInvocationHandler.Companion.EMPTY_ARGS
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+
+abstract class CoCacheProxy<K, V : Any, DELEGATE> :
+    InvocationHandler,
+    CacheDelegated<DELEGATE> where DELEGATE : Cache<K, V> {
+    abstract val proxyInterface: Class<*>
+
+    private val declaredDefaultMethods by lazy {
+        proxyInterface.declaredMethods.filter { it.isDefault }
+    }
+
+    @Suppress("SpreadOperator")
+    override fun invoke(proxy: Any, method: Method, args: Array<out Any>?): Any? {
+        val methodArgs = args ?: EMPTY_ARGS
+        if (method.isDefault && declaredDefaultMethods.contains(method)) {
+            return InvocationHandler.invokeDefault(proxy, method, *methodArgs)
+        }
+        return method.invoke(delegate, *methodArgs)
+    }
+}

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactory.kt
@@ -62,7 +62,7 @@ class DefaultCacheProxyFactory(
         )
         val invocationHandler = CoCacheInvocationHandler(cacheMetadata = cacheMetadata, delegate = delegate)
         return Proxy.newProxyInstance(
-            cacheMetadata.type.java.classLoader,
+            this.javaClass.classLoader,
             arrayOf(
                 cacheMetadata.type.java,
                 ComputedCache::class.java,

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactoryTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactoryTest.kt
@@ -63,4 +63,15 @@ class DefaultCacheProxyFactoryTest {
             )
         assertNull(cache.getCache("key"))
     }
+
+    @Test
+    fun defaultMethod() {
+        val cache =
+            createProxyCache<MockCacheWithKeyExpression>(
+                metadata = coCacheMetadata<MockCacheWithKeyExpression>().copy(
+                    keyExpression = "key"
+                )
+            )
+        assertEquals(cache.defaultMethod(), "defaultMethod")
+    }
 }

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/MockCache.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/MockCache.kt
@@ -28,4 +28,8 @@ interface MockCache :
     CacheMetadataCapable
 
 @CoCache(keyPrefix = "prefix:", keyExpression = "#{#root}")
-interface MockCacheWithKeyExpression : ComputedCache<String, String>
+interface MockCacheWithKeyExpression : ComputedCache<String, String> {
+    fun defaultMethod(): String {
+        return "defaultMethod"
+    }
+}


### PR DESCRIPTION
- Add support for default methods in cache proxy
- Introduce CoCacheProxy abstract class to handle default method invocation
- Update CoCacheInvocationHandler to use CoCacheProxy for method invocation
- Modify DefaultCacheProxyFactory to use system class loader for proxy creation
- Add test case for default method in cache proxy