### PR TITLE
refactor(cocache-core): improve CoCacheMetadataParser code readability 

### DIFF
--- a/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/CoCacheMetadata.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/CoCacheMetadata.kt
@@ -17,7 +17,7 @@ import me.ahoo.cache.api.NamedCache
 import kotlin.reflect.KClass
 
 data class CoCacheMetadata(
-    val type: KClass<*>,
+    val proxyInterface: KClass<*>,
     val name: String,
     val keyPrefix: String,
     val keyExpression: String,
@@ -25,6 +25,6 @@ data class CoCacheMetadata(
     val valueType: KClass<*>
 ) : NamedCache {
     override val cacheName: String = name.ifBlank {
-        type.simpleName!!
+        proxyInterface.simpleName!!
     }
 }

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParser.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParser.kt
@@ -24,15 +24,15 @@ object CoCacheMetadataParser {
     /**
      * 解析 CoCache 注解定义的 Cache 接口
      *
-     * @param cacheType 必须继承 `Cache` 接口，必须是接口
+     * @param proxyInterface 必须继承 `Cache` 接口，必须是接口
      */
-    fun parse(cacheType: KClass<out Cache<*, *>>): CoCacheMetadata {
-        require(cacheType.java.isInterface) {
-            "${cacheType.jvmName} must be interface."
+    fun parse(proxyInterface: KClass<out Cache<*, *>>): CoCacheMetadata {
+        require(proxyInterface.java.isInterface) {
+            "${proxyInterface.jvmName} must be interface."
         }
-        val coCacheAnnotation = cacheType.findAnnotation<CoCache>() ?: CoCache()
+        val coCacheAnnotation = proxyInterface.findAnnotation<CoCache>() ?: CoCache()
         // 获取继承的 Cache<K,V> 中 V 的具体类型
-        val superCacheType = cacheType.supertypes.first {
+        val superCacheType = proxyInterface.supertypes.first {
             it.classifier == Cache::class || it.classifier == ComputedCache::class
         }
         val keyType = superCacheType.arguments.first().type?.classifier as? KClass<*>
@@ -41,7 +41,7 @@ object CoCacheMetadataParser {
         requireNotNull(valueType)
 
         return CoCacheMetadata(
-            proxyInterface = cacheType,
+            proxyInterface = proxyInterface,
             name = coCacheAnnotation.name,
             keyPrefix = coCacheAnnotation.keyPrefix,
             keyExpression = coCacheAnnotation.keyExpression,

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParser.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParser.kt
@@ -41,7 +41,7 @@ object CoCacheMetadataParser {
         requireNotNull(valueType)
 
         return CoCacheMetadata(
-            type = cacheType,
+            proxyInterface = cacheType,
             name = coCacheAnnotation.name,
             keyPrefix = coCacheAnnotation.keyPrefix,
             keyExpression = coCacheAnnotation.keyExpression,

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/DefaultClientSideCacheFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/DefaultClientSideCacheFactory.kt
@@ -21,7 +21,7 @@ import kotlin.reflect.full.findAnnotation
 
 object DefaultClientSideCacheFactory : ClientSideCacheFactory {
     override fun <V> create(cacheMetadata: CoCacheMetadata): ClientSideCache<V> {
-        val guavaCache = cacheMetadata.type.findAnnotation<GuavaCache>() ?: return MapClientSideCache()
+        val guavaCache = cacheMetadata.proxyInterface.findAnnotation<GuavaCache>() ?: return MapClientSideCache()
         return guavaCache.toClientSideCache()
     }
 }

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/CoCacheInvocationHandler.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/CoCacheInvocationHandler.kt
@@ -19,12 +19,12 @@ import me.ahoo.cache.api.NamedCache
 import java.lang.reflect.Method
 import kotlin.reflect.jvm.javaGetter
 
-class CoCacheInvocationHandler<K, V : Any, DELEGATE>(
+class CoCacheInvocationHandler<DELEGATE>(
     override val cacheMetadata: CoCacheMetadata,
     override val delegate: DELEGATE
 ) : CacheDelegated<DELEGATE>,
     CacheMetadataCapable,
-    CoCacheProxy<K, V, DELEGATE>() where DELEGATE : Cache<K, V>, DELEGATE : NamedCache {
+    CoCacheProxy<DELEGATE>() where DELEGATE : Cache<*, *>, DELEGATE : NamedCache {
 
     companion object {
         val EMPTY_ARGS = emptyArray<Any>()
@@ -32,7 +32,7 @@ class CoCacheInvocationHandler<K, V : Any, DELEGATE>(
         val CACHE_METADATA_METHOD_SIGN: String = CacheMetadataCapable::cacheMetadata.javaGetter!!.name
     }
 
-    override val proxyInterface: Class<*> = cacheMetadata.type.java
+    override val proxyInterface: Class<*> = cacheMetadata.proxyInterface.java
 
     @Suppress("SpreadOperator", "ReturnCount")
     override fun invoke(proxy: Any, method: Method, args: Array<out Any>?): Any? {

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/CoCacheProxy.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/CoCacheProxy.kt
@@ -18,9 +18,9 @@ import me.ahoo.cache.proxy.CoCacheInvocationHandler.Companion.EMPTY_ARGS
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 
-abstract class CoCacheProxy<K, V : Any, DELEGATE> :
+abstract class CoCacheProxy<DELEGATE> :
     InvocationHandler,
-    CacheDelegated<DELEGATE> where DELEGATE : Cache<K, V> {
+    CacheDelegated<DELEGATE> where DELEGATE : Cache<*, *> {
     abstract val proxyInterface: Class<*>
 
     private val declaredDefaultMethods by lazy {

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactory.kt
@@ -64,7 +64,7 @@ class DefaultCacheProxyFactory(
         return Proxy.newProxyInstance(
             this.javaClass.classLoader,
             arrayOf(
-                cacheMetadata.type.java,
+                cacheMetadata.proxyInterface.java,
                 ComputedCache::class.java,
                 NamedCache::class.java,
                 CacheDelegated::class.java,
@@ -76,6 +76,6 @@ class DefaultCacheProxyFactory(
     }
 
     private fun CoCacheMetadata.resolveMissingGuardCache(): MissingGuardCache {
-        return type.findAnnotation<MissingGuardCache>() ?: return MissingGuardCache()
+        return proxyInterface.findAnnotation<MissingGuardCache>() ?: return MissingGuardCache()
     }
 }

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParserTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParserTest.kt
@@ -14,7 +14,7 @@ class CoCacheMetadataParserTest {
     @Test
     fun parse() {
         val metadata = coCacheMetadata<MockCache>()
-        assertThat(metadata.type, equalTo(MockCache::class))
+        assertThat(metadata.proxyInterface, equalTo(MockCache::class))
         assertThat(metadata.name, equalTo(""))
         assertThat(metadata.keyPrefix, equalTo(""))
         assertThat(metadata.keyType, equalTo(String::class))
@@ -24,7 +24,7 @@ class CoCacheMetadataParserTest {
     @Test
     fun parseComputedCache() {
         val metadata = coCacheMetadata<MockComputedCache>()
-        assertThat(metadata.type, equalTo(MockComputedCache::class))
+        assertThat(metadata.proxyInterface, equalTo(MockComputedCache::class))
         assertThat(metadata.name, equalTo(""))
         assertThat(metadata.keyPrefix, equalTo(""))
         assertThat(metadata.keyType, equalTo(String::class))
@@ -34,7 +34,7 @@ class CoCacheMetadataParserTest {
     @Test
     fun parseWithKeyExp() {
         val metadata = coCacheMetadata<MockCacheWithKeyExpression>()
-        assertThat(metadata.type, equalTo(MockCacheWithKeyExpression::class))
+        assertThat(metadata.proxyInterface, equalTo(MockCacheWithKeyExpression::class))
         assertThat(metadata.name, equalTo(""))
         assertThat(metadata.keyPrefix, equalTo("prefix:"))
         assertThat(metadata.keyExpression, equalTo("#{#root}"))

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/proxy/CacheProxyFactoryBean.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/proxy/CacheProxyFactoryBean.kt
@@ -34,6 +34,6 @@ class CacheProxyFactoryBean(private val cacheMetadata: CoCacheMetadata) :
     }
 
     override fun getObjectType(): Class<*> {
-        return cacheMetadata.type.java
+        return cacheMetadata.proxyInterface.java
     }
 }


### PR DESCRIPTION
- Rename parameter 'cacheType' to 'proxyInterface' for clarity
- Update function comments and variable names for better understanding
- Refactor code to enhance maintainability without changing functionality