### PR TITLE
feat(core): rename and restructure coherent cache classes

### DIFF
--- a/cocache-core/src/main/kotlin/me/ahoo/cache/CacheFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/CacheFactory.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cache
+
+import me.ahoo.cache.api.Cache
+
+interface CacheFactory {
+    val caches: Map<String, Cache<*, *>>
+    fun <CACHE : Cache<*, *>> getCache(cacheName: String): CACHE? {
+        return getCache(cacheName, Cache::class.java)
+    }
+
+    fun <CACHE : Cache<*, *>> getCache(cacheName: String, cacheType: Class<*>): CACHE?
+}

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/CoherentCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/CoherentCache.kt
@@ -11,25 +11,24 @@
  * limitations under the License.
  */
 
-package me.ahoo.cache.proxy
+package me.ahoo.cache.consistency
 
 import me.ahoo.cache.ComputedCache
-import me.ahoo.cache.api.annotation.CoCache
-import me.ahoo.cache.api.annotation.MissingGuardCache
-import me.ahoo.cache.consistency.DefaultCoherentCache
+import me.ahoo.cache.KeyFilter
+import me.ahoo.cache.api.NamedCache
+import me.ahoo.cache.api.client.ClientSideCache
+import me.ahoo.cache.api.source.CacheSource
+import me.ahoo.cache.converter.KeyConverter
+import me.ahoo.cache.distributed.DistributedCache
 import me.ahoo.cache.distributed.DistributedClientId
 
-@CoCache
-@MissingGuardCache(ttlSeconds = 120)
-interface MockCache :
-    ComputedCache<String, String>,
-    CacheDelegated<DefaultCoherentCache<String, String>>,
-    DistributedClientId,
-    CacheMetadataCapable
-
-@CoCache(keyPrefix = "prefix:", keyExpression = "#{#root}")
-interface MockCacheWithKeyExpression : ComputedCache<String, String> {
-    fun defaultMethod(): String {
-        return "defaultMethod"
-    }
+interface CoherentCache<K, V> : ComputedCache<K, V>, DistributedClientId, NamedCache, CacheEvictedSubscriber {
+    val cacheEvictedEventBus: CacheEvictedEventBus
+    val clientSideCache: ClientSideCache<V>
+    val distributedCache: DistributedCache<V>
+    val keyFilter: KeyFilter
+    val keyConverter: KeyConverter<K>
+    val missingGuardTtl: Long
+    val missingGuardTtlAmplitude: Long
+    val cacheSource: CacheSource<K, V>
 }

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/CoherentCacheConfiguration.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/CoherentCacheConfiguration.kt
@@ -11,49 +11,18 @@
  * limitations under the License.
  */
 
-package me.ahoo.cache
+package me.ahoo.cache.consistency
 
+import me.ahoo.cache.KeyFilter
 import me.ahoo.cache.api.NamedCache
 import me.ahoo.cache.api.annotation.MissingGuardCache
 import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.api.source.CacheSource
 import me.ahoo.cache.client.MapClientSideCache
-import me.ahoo.cache.consistency.CacheEvictedEventBus
 import me.ahoo.cache.converter.KeyConverter
 import me.ahoo.cache.distributed.DistributedCache
 import me.ahoo.cache.distributed.DistributedClientId
 import me.ahoo.cache.filter.NoOpKeyFilter
-import java.util.concurrent.ConcurrentHashMap
-
-class CacheManager(private val cacheEvictedEventBus: CacheEvictedEventBus) {
-
-    private val caches = ConcurrentHashMap<String, CoherentCache<*, *>>()
-
-    fun getCacheNames(): Set<String> {
-        return caches.keys
-    }
-
-    fun <K, V> getCache(cacheName: String): CoherentCache<K, V>? {
-        @Suppress("UNCHECKED_CAST")
-        return caches[cacheName] as CoherentCache<K, V>?
-    }
-
-    fun <K, V> createCache(cacheConfig: CoherentCacheConfiguration<K, V>): CoherentCache<K, V> {
-        val cache = CoherentCache(
-            config = cacheConfig,
-            cacheEvictedEventBus = cacheEvictedEventBus
-        )
-        cacheEvictedEventBus.register(cache)
-        return cache
-    }
-
-    fun <K, V> getOrCreateCache(cacheConfig: CoherentCacheConfiguration<K, V>): CoherentCache<K, V> {
-        @Suppress("UNCHECKED_CAST")
-        return caches.computeIfAbsent(cacheConfig.cacheName) {
-            createCache(cacheConfig)
-        } as CoherentCache<K, V>
-    }
-}
 
 data class CoherentCacheConfiguration<K, V>(
     override val cacheName: String,

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/CoherentCacheFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/CoherentCacheFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cache.consistency
+
+interface CoherentCacheFactory {
+    fun <K, V> create(cacheConfig: CoherentCacheConfiguration<K, V>): CoherentCache<K, V>
+}

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/DefaultCoherentCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/DefaultCoherentCache.kt
@@ -10,18 +10,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package me.ahoo.cache
+package me.ahoo.cache.consistency
 
 import com.google.common.eventbus.Subscribe
+import me.ahoo.cache.DefaultCacheValue
+import me.ahoo.cache.KeyFilter
 import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.api.NamedCache
 import me.ahoo.cache.api.annotation.MissingGuardCache
 import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.api.source.CacheSource
 import me.ahoo.cache.client.MapClientSideCache
-import me.ahoo.cache.consistency.CacheEvictedEvent
-import me.ahoo.cache.consistency.CacheEvictedEventBus
-import me.ahoo.cache.consistency.CacheEvictedSubscriber
 import me.ahoo.cache.converter.KeyConverter
 import me.ahoo.cache.distributed.DistributedCache
 import me.ahoo.cache.distributed.DistributedClientId
@@ -34,10 +33,10 @@ import org.slf4j.LoggerFactory
  * @author ahoo wang
  */
 @Suppress("LongParameterList")
-class CoherentCache<K, V>(
+class DefaultCoherentCache<K, V>(
     val config: CoherentCacheConfiguration<K, V>,
-    val cacheEvictedEventBus: CacheEvictedEventBus
-) : ComputedCache<K, V>, DistributedClientId by config, NamedCache by config, CacheEvictedSubscriber {
+    override val cacheEvictedEventBus: CacheEvictedEventBus
+) : CoherentCache<K, V>, DistributedClientId by config, NamedCache by config {
 
     constructor(
         cacheName: String,
@@ -66,16 +65,16 @@ class CoherentCache<K, V>(
     )
 
     companion object {
-        private val log = LoggerFactory.getLogger(CoherentCache::class.java)
+        private val log = LoggerFactory.getLogger(DefaultCoherentCache::class.java)
     }
 
-    val clientSideCache = config.clientSideCache
-    val distributedCache = config.distributedCache
-    val keyFilter = config.keyFilter
-    val keyConverter = config.keyConverter
-    val missingGuardTtl = config.missingGuardTtl
-    val missingGuardTtlAmplitude = config.missingGuardTtlAmplitude
-    val cacheSource = config.cacheSource
+    override val clientSideCache = config.clientSideCache
+    override val distributedCache = config.distributedCache
+    override val keyFilter = config.keyFilter
+    override val keyConverter = config.keyConverter
+    override val missingGuardTtl = config.missingGuardTtl
+    override val missingGuardTtlAmplitude = config.missingGuardTtlAmplitude
+    override val cacheSource = config.cacheSource
 
     @Suppress("ReturnCount")
     private fun getL2Cache(cacheKey: String): CacheValue<V>? {

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/DefaultCoherentCacheFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/DefaultCoherentCacheFactory.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cache.consistency
+
+class DefaultCoherentCacheFactory(private val cacheEvictedEventBus: CacheEvictedEventBus) : CoherentCacheFactory {
+    override fun <K, V> create(cacheConfig: CoherentCacheConfiguration<K, V>): DefaultCoherentCache<K, V> {
+        val coherentCache = DefaultCoherentCache<K, V>(
+            config = cacheConfig,
+            cacheEvictedEventBus = cacheEvictedEventBus
+        )
+        cacheEvictedEventBus.register(coherentCache)
+        return coherentCache
+    }
+}

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactory.kt
@@ -15,7 +15,6 @@ package me.ahoo.cache.proxy
 
 import me.ahoo.cache.annotation.CoCacheMetadata
 import me.ahoo.cache.api.Cache
-import me.ahoo.cache.api.NamedCache
 import me.ahoo.cache.api.annotation.MissingGuardCache
 import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.client.ClientSideCacheFactory
@@ -25,7 +24,6 @@ import me.ahoo.cache.consistency.CoherentCacheFactory
 import me.ahoo.cache.converter.KeyConverterFactory
 import me.ahoo.cache.distributed.DistributedCache
 import me.ahoo.cache.distributed.DistributedCacheFactory
-import me.ahoo.cache.distributed.DistributedClientId
 import me.ahoo.cache.source.CacheSourceFactory
 import me.ahoo.cache.util.ClientIdGenerator
 import java.lang.reflect.Proxy
@@ -66,9 +64,7 @@ class DefaultCacheProxyFactory(
             arrayOf(
                 cacheMetadata.proxyInterface.java,
                 CoherentCache::class.java,
-                NamedCache::class.java,
                 CacheDelegated::class.java,
-                DistributedClientId::class.java,
                 CacheMetadataCapable::class.java
             ),
             invocationHandler

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactory.kt
@@ -13,15 +13,15 @@
 
 package me.ahoo.cache.proxy
 
-import me.ahoo.cache.CacheManager
-import me.ahoo.cache.CoherentCacheConfiguration
-import me.ahoo.cache.ComputedCache
 import me.ahoo.cache.annotation.CoCacheMetadata
 import me.ahoo.cache.api.Cache
 import me.ahoo.cache.api.NamedCache
 import me.ahoo.cache.api.annotation.MissingGuardCache
 import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.client.ClientSideCacheFactory
+import me.ahoo.cache.consistency.CoherentCache
+import me.ahoo.cache.consistency.CoherentCacheConfiguration
+import me.ahoo.cache.consistency.CoherentCacheFactory
 import me.ahoo.cache.converter.KeyConverterFactory
 import me.ahoo.cache.distributed.DistributedCache
 import me.ahoo.cache.distributed.DistributedCacheFactory
@@ -32,7 +32,7 @@ import java.lang.reflect.Proxy
 import kotlin.reflect.full.findAnnotation
 
 class DefaultCacheProxyFactory(
-    private val cacheManager: CacheManager,
+    private val coherentCacheFactory: CoherentCacheFactory,
     private val clientIdGenerator: ClientIdGenerator,
     private val clientSideCacheFactory: ClientSideCacheFactory,
     private val distributedCacheFactory: DistributedCacheFactory,
@@ -48,7 +48,7 @@ class DefaultCacheProxyFactory(
         val cacheSource = cacheSourceFactory.create<Any, Any>(cacheMetadata)
         val missingGuardCache = cacheMetadata.resolveMissingGuardCache()
         val keyConverter = keyConverterFactory.create<Any>(cacheMetadata)
-        val delegate = cacheManager.getOrCreateCache(
+        val delegate = coherentCacheFactory.create(
             CoherentCacheConfiguration(
                 cacheName = cacheMetadata.cacheName,
                 clientId = clientId,
@@ -65,7 +65,7 @@ class DefaultCacheProxyFactory(
             this.javaClass.classLoader,
             arrayOf(
                 cacheMetadata.proxyInterface.java,
-                ComputedCache::class.java,
+                CoherentCache::class.java,
                 NamedCache::class.java,
                 CacheDelegated::class.java,
                 DistributedClientId::class.java,

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/consistency/DefaultCoherentCacheTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/consistency/DefaultCoherentCacheTest.kt
@@ -10,17 +10,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package me.ahoo.cache
+package me.ahoo.cache.consistency
 
 import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.client.MapClientSideCache
-import me.ahoo.cache.consistency.CacheEvictedEventBus
-import me.ahoo.cache.consistency.GuavaCacheEvictedEventBus
 import me.ahoo.cache.converter.KeyConverter
 import me.ahoo.cache.converter.ToStringKeyConverter
 import me.ahoo.cache.distributed.DistributedCache
 import me.ahoo.cache.distributed.mock.MockDistributedCache
-import me.ahoo.cache.test.CoherentCacheSpec
+import me.ahoo.cache.test.DefaultCoherentCacheSpec
 import java.util.*
 
 /**
@@ -28,7 +26,7 @@ import java.util.*
  *
  * @author ahoo wang
  */
-internal class CoherentCacheTest : CoherentCacheSpec<String, String>() {
+internal class DefaultCoherentCacheTest : DefaultCoherentCacheSpec<String, String>() {
 
     override fun createKeyConverter(): KeyConverter<String> = ToStringKeyConverter("")
 

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactoryTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/proxy/DefaultCacheProxyFactoryTest.kt
@@ -1,11 +1,11 @@
 package me.ahoo.cache.proxy
 
-import me.ahoo.cache.CacheManager
-import me.ahoo.cache.CoherentCache
 import me.ahoo.cache.annotation.CoCacheMetadata
 import me.ahoo.cache.annotation.coCacheMetadata
 import me.ahoo.cache.api.source.CacheSource
 import me.ahoo.cache.client.DefaultClientSideCacheFactory
+import me.ahoo.cache.consistency.CoherentCache
+import me.ahoo.cache.consistency.DefaultCoherentCacheFactory
 import me.ahoo.cache.consistency.NoOpCacheEvictedEventBus
 import me.ahoo.cache.converter.DefaultKeyConverterFactory
 import me.ahoo.cache.distributed.DistributedCache
@@ -31,7 +31,7 @@ class DefaultCacheProxyFactoryTest {
                 }
             }
             val cacheProxyFactory = DefaultCacheProxyFactory(
-                cacheManager = CacheManager(NoOpCacheEvictedEventBus),
+                coherentCacheFactory = DefaultCoherentCacheFactory(NoOpCacheEvictedEventBus),
                 clientIdGenerator = ClientIdGenerator.UUID,
                 clientSideCacheFactory = DefaultClientSideCacheFactory,
                 distributedCacheFactory = distributedCacheFactory,

--- a/cocache-example/src/main/kotlin/me/ahoo/cache/example/config/ClassDefinedCacheConfiguration.kt
+++ b/cocache-example/src/main/kotlin/me/ahoo/cache/example/config/ClassDefinedCacheConfiguration.kt
@@ -14,11 +14,11 @@ package me.ahoo.cache.example.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.cache.CacheBuilder
-import me.ahoo.cache.CoherentCacheConfiguration
-import me.ahoo.cache.CacheManager
 import me.ahoo.cache.api.CacheValue
-import me.ahoo.cache.CoherentCache
 import me.ahoo.cache.client.GuavaClientSideCache
+import me.ahoo.cache.consistency.CoherentCache
+import me.ahoo.cache.consistency.CoherentCacheConfiguration
+import me.ahoo.cache.consistency.CoherentCacheFactory
 import me.ahoo.cache.converter.ToStringKeyConverter
 import me.ahoo.cache.distributed.DistributedCache
 import me.ahoo.cache.distributed.mock.MockDistributedCache
@@ -36,7 +36,7 @@ class ClassDefinedCacheConfiguration {
     @Bean("userCache")
     fun userCache(
         redisTemplate: StringRedisTemplate,
-        cacheManager: CacheManager,
+        coherentCacheFactory: CoherentCacheFactory,
         objectMapper: ObjectMapper,
         clientIdGenerator: ClientIdGenerator
     ): CoherentCache<String, User> {
@@ -49,7 +49,7 @@ class ClassDefinedCacheConfiguration {
 
         val distributedCaching: DistributedCache<User> = RedisDistributedCache(redisTemplate, codecExecutor)
 
-        return cacheManager.getOrCreateCache(
+        return coherentCacheFactory.create(
             CoherentCacheConfiguration(
                 cacheName = "userCache",
                 clientId = clientId,
@@ -66,12 +66,15 @@ class ClassDefinedCacheConfiguration {
     }
 
     @Bean("mockCache")
-    fun mockCache(cacheManager: CacheManager, clientIdGenerator: ClientIdGenerator): CoherentCache<String, String> {
+    fun mockCache(
+        coherentCacheFactory: CoherentCacheFactory,
+        clientIdGenerator: ClientIdGenerator
+    ): CoherentCache<String, String> {
         val distributedCaching = MockDistributedCache<String>()
         val clientId = clientIdGenerator.generate()
-        return cacheManager.getOrCreateCache(
+        return coherentCacheFactory.create(
             CoherentCacheConfiguration(
-                cacheName = "userCache",
+                cacheName = "mockCache",
                 clientId = clientId,
                 keyConverter = ToStringKeyConverter(""),
                 distributedCache = distributedCaching,

--- a/cocache-example/src/main/kotlin/me/ahoo/cache/example/controller/TestController.kt
+++ b/cocache-example/src/main/kotlin/me/ahoo/cache/example/controller/TestController.kt
@@ -12,7 +12,8 @@
  */
 package me.ahoo.cache.example.controller
 
-import me.ahoo.cache.CoherentCache
+import me.ahoo.cache.consistency.CoherentCache
+import me.ahoo.cache.consistency.DefaultCoherentCache
 import me.ahoo.cache.example.cache.UserCache
 import me.ahoo.cache.example.model.User
 import org.springframework.beans.factory.annotation.Qualifier

--- a/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfiguration.kt
+++ b/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfiguration.kt
@@ -12,14 +12,17 @@
  */
 package me.ahoo.cache.spring.boot.starter
 
-import me.ahoo.cache.CacheManager
+import me.ahoo.cache.CacheFactory
 import me.ahoo.cache.client.ClientSideCacheFactory
 import me.ahoo.cache.consistency.CacheEvictedEventBus
+import me.ahoo.cache.consistency.CoherentCacheFactory
+import me.ahoo.cache.consistency.DefaultCoherentCacheFactory
 import me.ahoo.cache.converter.KeyConverterFactory
 import me.ahoo.cache.distributed.DistributedCacheFactory
 import me.ahoo.cache.proxy.CacheProxyFactory
 import me.ahoo.cache.proxy.DefaultCacheProxyFactory
 import me.ahoo.cache.source.CacheSourceFactory
+import me.ahoo.cache.spring.SpringCacheFactory
 import me.ahoo.cache.spring.client.SpringClientSideCacheFactory
 import me.ahoo.cache.spring.converter.SpringKeyConverterFactory
 import me.ahoo.cache.spring.redis.RedisCacheEvictedEventBus
@@ -29,6 +32,7 @@ import me.ahoo.cache.util.ClientIdGenerator
 import me.ahoo.cache.util.HostClientIdGenerator
 import me.ahoo.cosid.machine.HostAddressSupplier
 import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.ListableBeanFactory
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
@@ -63,6 +67,12 @@ class CoCacheAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    fun cacheFactory(beanFactory: ListableBeanFactory): CacheFactory {
+        return SpringCacheFactory(beanFactory)
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
     @ConditionalOnSingleCandidate(RedisConnectionFactory::class)
     fun cocacheRedisMessageListenerContainer(
         redisConnectionFactory: RedisConnectionFactory
@@ -83,8 +93,8 @@ class CoCacheAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun cacheManager(cacheEvictedEventBus: CacheEvictedEventBus): CacheManager {
-        return CacheManager(cacheEvictedEventBus)
+    fun coherentCacheFactory(cacheEvictedEventBus: CacheEvictedEventBus): CoherentCacheFactory {
+        return DefaultCoherentCacheFactory(cacheEvictedEventBus)
     }
 
     @Bean
@@ -115,7 +125,7 @@ class CoCacheAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     fun cacheProxyFactory(
-        cacheManager: CacheManager,
+        coherentCacheFactory: CoherentCacheFactory,
         clientIdGenerator: ClientIdGenerator,
         clientSideCacheFactory: ClientSideCacheFactory,
         distributedCacheFactory: DistributedCacheFactory,
@@ -123,7 +133,7 @@ class CoCacheAutoConfiguration {
         keyConverterFactory: KeyConverterFactory
     ): CacheProxyFactory {
         return DefaultCacheProxyFactory(
-            cacheManager,
+            coherentCacheFactory,
             clientIdGenerator,
             clientSideCacheFactory,
             distributedCacheFactory,

--- a/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheEndpoint.kt
+++ b/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheEndpoint.kt
@@ -13,10 +13,11 @@
 
 package me.ahoo.cache.spring.boot.starter
 
-import me.ahoo.cache.CacheManager
-import me.ahoo.cache.CoherentCache
+import me.ahoo.cache.CacheFactory
 import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.api.annotation.CoCache
+import me.ahoo.cache.consistency.CoherentCache
+import me.ahoo.cache.consistency.DefaultCoherentCache
 import me.ahoo.cache.spring.boot.starter.CoCacheEndpoint.CacheReport.Companion.asReport
 import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint
@@ -24,28 +25,31 @@ import org.springframework.boot.actuate.endpoint.annotation.ReadOperation
 import org.springframework.boot.actuate.endpoint.annotation.Selector
 
 @Endpoint(id = CoCache.COCACHE)
-class CoCacheEndpoint(private val cacheManager: CacheManager) {
+class CoCacheEndpoint(private val cacheFactory: CacheFactory) {
 
     @ReadOperation
     fun total(): List<CacheReport> {
-        return cacheManager.getCacheNames().mapNotNull {
-            cacheManager.getCache<String, Any>(it)?.asReport()
+        return cacheFactory.caches.filter {
+            it.value is CoherentCache
+        }.map {
+            val coherentCache = it.value as CoherentCache<*, *>
+            coherentCache.asReport(it.key)
         }.toList()
     }
 
     @ReadOperation
     fun stat(@Selector name: String): CacheReport? {
-        return cacheManager.getCache<String, Any>(name)?.asReport()
+        return cacheFactory.getCache<DefaultCoherentCache<String, Any>>(name)?.asReport(name)
     }
 
     @DeleteOperation
     fun evict(@Selector name: String, @Selector key: String) {
-        cacheManager.getCache<String, Any>(name)?.evict(key)
+        cacheFactory.getCache<DefaultCoherentCache<String, Any>>(name)?.evict(key)
     }
 
     @ReadOperation
     fun get(@Selector name: String, @Selector key: String): CacheValue<*>? {
-        return cacheManager.getCache<String, Any>(name)?.getCache(key)
+        return cacheFactory.getCache<DefaultCoherentCache<String, Any>>(name)?.getCache(key)
     }
 
     data class CacheReport(
@@ -61,7 +65,7 @@ class CoCacheEndpoint(private val cacheManager: CacheManager) {
         val missingGuardTtl: Long
     ) {
         companion object {
-            fun CoherentCache<*, *>.asReport(): CacheReport {
+            fun CoherentCache<*, *>.asReport(cacheName: String): CacheReport {
                 return CacheReport(
                     name = cacheName,
                     clientId = clientId,

--- a/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheEndpointAutoConfiguration.kt
+++ b/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheEndpointAutoConfiguration.kt
@@ -12,7 +12,7 @@
  */
 package me.ahoo.cache.spring.boot.starter
 
-import me.ahoo.cache.CacheManager
+import me.ahoo.cache.CacheFactory
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
@@ -31,13 +31,13 @@ class CoCacheEndpointAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun cocacheEndpoint(cacheManager: CacheManager): CoCacheEndpoint {
-        return CoCacheEndpoint(cacheManager)
+    fun cocacheEndpoint(cacheFactory: CacheFactory): CoCacheEndpoint {
+        return CoCacheEndpoint(cacheFactory)
     }
 
     @Bean
     @ConditionalOnMissingBean
-    fun coCacheClientEndpoint(cacheManager: CacheManager): CoCacheClientEndpoint {
-        return CoCacheClientEndpoint(cacheManager)
+    fun coCacheClientEndpoint(cacheFactory: CacheFactory): CoCacheClientEndpoint {
+        return CoCacheClientEndpoint(cacheFactory)
     }
 }

--- a/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/AbstractCoCacheEndpointTest.kt
+++ b/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/AbstractCoCacheEndpointTest.kt
@@ -1,9 +1,14 @@
 package me.ahoo.cache.spring.boot.starter
 
-import me.ahoo.cache.CacheManager
-import me.ahoo.cache.CoherentCacheConfiguration
+import io.mockk.every
+import io.mockk.mockk
+import me.ahoo.cache.CacheFactory
+import me.ahoo.cache.api.Cache
 import me.ahoo.cache.client.MapClientSideCache
-import me.ahoo.cache.consistency.GuavaCacheEvictedEventBus
+import me.ahoo.cache.consistency.CoherentCache
+import me.ahoo.cache.consistency.CoherentCacheConfiguration
+import me.ahoo.cache.consistency.DefaultCoherentCache
+import me.ahoo.cache.consistency.NoOpCacheEvictedEventBus
 import me.ahoo.cache.converter.ToStringKeyConverter
 import me.ahoo.cache.distributed.mock.MockDistributedCache
 import org.junit.jupiter.api.BeforeEach
@@ -13,22 +18,43 @@ open class AbstractCoCacheEndpointTest {
         const val CACHE_NAME = "cacheName"
     }
 
-    lateinit var cacheManager: CacheManager
+    lateinit var cacheFactory: CacheFactory
 
     @BeforeEach
     open fun setup() {
-        val keyConverter = ToStringKeyConverter<String>("")
         val clientSideCaching = MapClientSideCache<String>()
         val distributedCaching = MockDistributedCache<String>()
-        cacheManager = CacheManager(GuavaCacheEvictedEventBus())
-        cacheManager.getOrCreateCache(
+        val mockCache = DefaultCoherentCache<String, String>(
             CoherentCacheConfiguration(
-                cacheName = CACHE_NAME,
-                clientId = "currentClientId",
-                keyConverter = keyConverter,
-                distributedCache = distributedCaching,
-                clientSideCache = clientSideCaching,
+                CACHE_NAME,
+                "clientId",
+                ToStringKeyConverter("keyPrefix"),
+                distributedCaching,
+                clientSideCaching,
+                missingGuardTtl = 1,
+                missingGuardTtlAmplitude = 1
             ),
+            NoOpCacheEvictedEventBus
         )
+
+        cacheFactory = mockk {
+            every {
+                caches
+            } returns mapOf(
+                CACHE_NAME to mockCache
+            )
+            every {
+                getCache<Cache<String, String>>(CACHE_NAME)
+            } returns mockCache
+            every {
+                getCache<Cache<String, String>>(CACHE_NAME)
+            } returns mockCache
+            every {
+                getCache<CoherentCache<String, String>>(CACHE_NAME, CoherentCache::class.java)
+            } returns mockCache
+            every {
+                getCache<CoherentCache<String, String>>("CACHE_NAME", any())
+            } returns null
+        }
     }
 }

--- a/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfigurationTest.kt
+++ b/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfigurationTest.kt
@@ -13,7 +13,7 @@
 
 package me.ahoo.cache.spring.boot.starter
 
-import me.ahoo.cache.CacheManager
+import me.ahoo.cache.CacheFactory
 import me.ahoo.cache.consistency.CacheEvictedEventBus
 import me.ahoo.cache.example.cache.UserCache
 import me.ahoo.cache.spring.boot.starter.auto.EnableCoCacheConfiguration
@@ -46,7 +46,7 @@ internal class CoCacheAutoConfigurationTest {
                     .hasSingleBean(ClientIdGenerator::class.java)
                     .hasSingleBean(RedisMessageListenerContainer::class.java)
                     .hasSingleBean(CacheEvictedEventBus::class.java)
-                    .hasSingleBean(CacheManager::class.java)
+                    .hasSingleBean(CacheFactory::class.java)
                     .hasSingleBean(UserCache::class.java)
 
                 context.getBean(UserCache::class.java)
@@ -67,7 +67,7 @@ internal class CoCacheAutoConfigurationTest {
                     .hasSingleBean(ClientIdGenerator::class.java)
                     .hasSingleBean(RedisMessageListenerContainer::class.java)
                     .hasSingleBean(CacheEvictedEventBus::class.java)
-                    .hasSingleBean(CacheManager::class.java)
+                    .hasSingleBean(CacheFactory::class.java)
                     .hasSingleBean(UserCache::class.java)
 
                 context.getBean(UserCache::class.java)
@@ -90,7 +90,7 @@ internal class CoCacheAutoConfigurationTest {
                     .hasSingleBean(ClientIdGenerator::class.java)
                     .hasSingleBean(RedisMessageListenerContainer::class.java)
                     .hasSingleBean(CacheEvictedEventBus::class.java)
-                    .hasSingleBean(CacheManager::class.java)
+                    .hasSingleBean(CacheFactory::class.java)
                 context.getBean(ClientIdGenerator::class.java).generate()
             }
     }

--- a/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheClientEndpointTest.kt
+++ b/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheClientEndpointTest.kt
@@ -1,5 +1,6 @@
 package me.ahoo.cache.spring.boot.starter
 
+import me.ahoo.cache.api.Cache
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.BeforeEach
@@ -11,7 +12,7 @@ class CoCacheClientEndpointTest : AbstractCoCacheEndpointTest() {
     @BeforeEach
     override fun setup() {
         super.setup()
-        endpoint = CoCacheClientEndpoint(cacheManager)
+        endpoint = CoCacheClientEndpoint(cacheFactory)
     }
 
     @Test
@@ -31,7 +32,7 @@ class CoCacheClientEndpointTest : AbstractCoCacheEndpointTest() {
 
     @Test
     fun clear() {
-        val cache = cacheManager.getCache<String, String>(CACHE_NAME)!!
+        val cache = cacheFactory.getCache<Cache<String, String>>(CACHE_NAME)!!
         val key = "clear-key"
         cache[key] = "value"
         assertThat(endpoint.getSize(CACHE_NAME), equalTo(1))

--- a/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheEndpointTest.kt
+++ b/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheEndpointTest.kt
@@ -1,5 +1,6 @@
 package me.ahoo.cache.spring.boot.starter
 
+import me.ahoo.cache.api.Cache
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.BeforeEach
@@ -11,7 +12,7 @@ class CoCacheEndpointTest : AbstractCoCacheEndpointTest() {
     @BeforeEach
     override fun setup() {
         super.setup()
-        endpoint = CoCacheEndpoint(cacheManager)
+        endpoint = CoCacheEndpoint(cacheFactory)
     }
 
     @Test
@@ -26,7 +27,7 @@ class CoCacheEndpointTest : AbstractCoCacheEndpointTest() {
 
     @Test
     fun evict() {
-        val cache = cacheManager.getCache<String, String>(CACHE_NAME)!!
+        val cache = cacheFactory.getCache<Cache<String, String>>(CACHE_NAME)!!
         val key = "evict-key"
         cache[key] = "value"
         endpoint.evict(CACHE_NAME, key)
@@ -35,7 +36,7 @@ class CoCacheEndpointTest : AbstractCoCacheEndpointTest() {
 
     @Test
     fun get() {
-        val cache = cacheManager.getCache<String, String>(CACHE_NAME)!!
+        val cache = cacheFactory.getCache<Cache<String, String>>(CACHE_NAME)!!
         val key = "get-key"
         cache[key] = "value"
         assertThat(endpoint.get(CACHE_NAME, key)?.value, equalTo("value"))

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/SpringCacheFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/SpringCacheFactory.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cache.spring
+
+import me.ahoo.cache.CacheFactory
+import me.ahoo.cache.api.Cache
+import org.springframework.beans.factory.ListableBeanFactory
+import org.springframework.beans.factory.NoSuchBeanDefinitionException
+
+class SpringCacheFactory(private val beanFactory: ListableBeanFactory) : CacheFactory {
+    override val caches: Map<String, Cache<*, *>>
+        get() {
+            return beanFactory.getBeansOfType(Cache::class.java)
+        }
+
+    @Suppress("UNCHECKED_CAST", "SwallowedException")
+    override fun <CACHE : Cache<*, *>> getCache(cacheName: String, cacheType: Class<*>): CACHE? {
+        return try {
+            beanFactory.getBean(cacheName, cacheType::class.java) as CACHE
+        } catch (error: NoSuchBeanDefinitionException) {
+            null
+        }
+    }
+}

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/DefaultCoherentCacheSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/DefaultCoherentCacheSpec.kt
@@ -13,7 +13,6 @@
 
 package me.ahoo.cache.test
 
-import me.ahoo.cache.CoherentCache
 import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.api.Cache
 import me.ahoo.cache.api.CacheValue
@@ -21,6 +20,9 @@ import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.api.source.CacheSource
 import me.ahoo.cache.consistency.CacheEvictedEvent
 import me.ahoo.cache.consistency.CacheEvictedEventBus
+import me.ahoo.cache.consistency.CoherentCacheConfiguration
+import me.ahoo.cache.consistency.DefaultCoherentCache
+import me.ahoo.cache.consistency.DefaultCoherentCacheFactory
 import me.ahoo.cache.converter.KeyConverter
 import me.ahoo.cache.distributed.DistributedCache
 import org.hamcrest.MatcherAssert.assertThat
@@ -30,7 +32,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.*
 
-abstract class CoherentCacheSpec<K, V> : CacheSpec<K, V>() {
+abstract class DefaultCoherentCacheSpec<K, V> : CacheSpec<K, V>() {
     companion object {
         private val CACHE_SOURCE_VALUE = ThreadLocal<CacheValue<*>>()
     }
@@ -39,7 +41,7 @@ abstract class CoherentCacheSpec<K, V> : CacheSpec<K, V>() {
     private lateinit var clientSideCache: ClientSideCache<V>
     private lateinit var distributedCache: DistributedCache<V>
     private lateinit var cacheEvictedEventBus: CacheEvictedEventBus
-    private lateinit var coherentCache: CoherentCache<K, V>
+    private lateinit var coherentCache: DefaultCoherentCache<K, V>
     protected lateinit var cacheName: String
     protected val clientId: String = UUID.randomUUID().toString()
 
@@ -56,15 +58,15 @@ abstract class CoherentCacheSpec<K, V> : CacheSpec<K, V>() {
         distributedCache = createDistributedCache()
         cacheEvictedEventBus = createCacheEvictedEventBus()
         cacheName = createCacheName()
-
-        coherentCache = CoherentCache(
-            cacheName = cacheName,
-            clientId = clientId,
-            keyConverter = keyConverter,
-            clientSideCache = clientSideCache,
-            distributedCache = distributedCache,
-            cacheSource = cacheSource,
-            cacheEvictedEventBus = cacheEvictedEventBus
+        coherentCache = DefaultCoherentCacheFactory(cacheEvictedEventBus).create(
+            CoherentCacheConfiguration(
+                cacheName = cacheName,
+                clientId = clientId,
+                keyConverter = keyConverter,
+                clientSideCache = clientSideCache,
+                distributedCache = distributedCache,
+                cacheSource = cacheSource
+            )
         )
         super.setup()
     }


### PR DESCRIPTION
- Rename CoherentCache to DefaultCoherentCache
- Rename CoherentCacheConfiguration to CoherentCacheConfiguration (keep unchanged)
- Create new CoherentCache interface for computed cache
- Implement DefaultCoherentCacheFactory to create coherent caches
- Update related test classes and configurations