### PR TITLE
refactor(cocache): remove redundant DefaultCoherentCache imports

### DIFF
--- a/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/DefaultCoherentCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/DefaultCoherentCache.kt
@@ -14,17 +14,9 @@ package me.ahoo.cache.consistency
 
 import com.google.common.eventbus.Subscribe
 import me.ahoo.cache.DefaultCacheValue
-import me.ahoo.cache.KeyFilter
 import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.api.NamedCache
-import me.ahoo.cache.api.annotation.MissingGuardCache
-import me.ahoo.cache.api.client.ClientSideCache
-import me.ahoo.cache.api.source.CacheSource
-import me.ahoo.cache.client.MapClientSideCache
-import me.ahoo.cache.converter.KeyConverter
-import me.ahoo.cache.distributed.DistributedCache
 import me.ahoo.cache.distributed.DistributedClientId
-import me.ahoo.cache.filter.NoOpKeyFilter
 import org.slf4j.LoggerFactory
 
 /**
@@ -37,32 +29,6 @@ class DefaultCoherentCache<K, V>(
     val config: CoherentCacheConfiguration<K, V>,
     override val cacheEvictedEventBus: CacheEvictedEventBus
 ) : CoherentCache<K, V>, DistributedClientId by config, NamedCache by config {
-
-    constructor(
-        cacheName: String,
-        clientId: String,
-        keyConverter: KeyConverter<K>,
-        clientSideCache: ClientSideCache<V> = MapClientSideCache(),
-        distributedCache: DistributedCache<V>,
-        cacheSource: CacheSource<K, V> = CacheSource.noOp(),
-        keyFilter: KeyFilter = NoOpKeyFilter,
-        missingGuardTtl: Long = MissingGuardCache.DEFAULT_TTL_SECONDS,
-        missingGuardTtlAmplitude: Long = MissingGuardCache.DEFAULT_TTL_AMPLITUDE_SECONDS,
-        cacheEvictedEventBus: CacheEvictedEventBus
-    ) : this(
-        CoherentCacheConfiguration(
-            cacheName = cacheName,
-            clientId = clientId,
-            keyConverter = keyConverter,
-            clientSideCache = clientSideCache,
-            distributedCache = distributedCache,
-            cacheSource = cacheSource,
-            keyFilter = keyFilter,
-            missingGuardTtl = missingGuardTtl,
-            missingGuardTtlAmplitude = missingGuardTtlAmplitude
-        ),
-        cacheEvictedEventBus = cacheEvictedEventBus,
-    )
 
     companion object {
         private val log = LoggerFactory.getLogger(DefaultCoherentCache::class.java)

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/DefaultCoherentCacheFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/DefaultCoherentCacheFactory.kt
@@ -14,8 +14,8 @@
 package me.ahoo.cache.consistency
 
 class DefaultCoherentCacheFactory(private val cacheEvictedEventBus: CacheEvictedEventBus) : CoherentCacheFactory {
-    override fun <K, V> create(cacheConfig: CoherentCacheConfiguration<K, V>): DefaultCoherentCache<K, V> {
-        val coherentCache = DefaultCoherentCache<K, V>(
+    override fun <K, V> create(cacheConfig: CoherentCacheConfiguration<K, V>): CoherentCache<K, V> {
+        val coherentCache = DefaultCoherentCache(
             config = cacheConfig,
             cacheEvictedEventBus = cacheEvictedEventBus
         )

--- a/cocache-example/src/main/kotlin/me/ahoo/cache/example/controller/TestController.kt
+++ b/cocache-example/src/main/kotlin/me/ahoo/cache/example/controller/TestController.kt
@@ -13,7 +13,6 @@
 package me.ahoo.cache.example.controller
 
 import me.ahoo.cache.consistency.CoherentCache
-import me.ahoo.cache.consistency.DefaultCoherentCache
 import me.ahoo.cache.example.cache.UserCache
 import me.ahoo.cache.example.model.User
 import org.springframework.beans.factory.annotation.Qualifier
@@ -22,7 +21,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
+import java.util.*
 
 /**
  * TestController .

--- a/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheEndpoint.kt
+++ b/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheEndpoint.kt
@@ -17,7 +17,6 @@ import me.ahoo.cache.CacheFactory
 import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.api.annotation.CoCache
 import me.ahoo.cache.consistency.CoherentCache
-import me.ahoo.cache.consistency.DefaultCoherentCache
 import me.ahoo.cache.spring.boot.starter.CoCacheEndpoint.CacheReport.Companion.asReport
 import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint
@@ -39,17 +38,17 @@ class CoCacheEndpoint(private val cacheFactory: CacheFactory) {
 
     @ReadOperation
     fun stat(@Selector name: String): CacheReport? {
-        return cacheFactory.getCache<DefaultCoherentCache<String, Any>>(name)?.asReport(name)
+        return cacheFactory.getCache<CoherentCache<String, Any>>(name)?.asReport(name)
     }
 
     @DeleteOperation
     fun evict(@Selector name: String, @Selector key: String) {
-        cacheFactory.getCache<DefaultCoherentCache<String, Any>>(name)?.evict(key)
+        cacheFactory.getCache<CoherentCache<String, Any>>(name)?.evict(key)
     }
 
     @ReadOperation
     fun get(@Selector name: String, @Selector key: String): CacheValue<*>? {
-        return cacheFactory.getCache<DefaultCoherentCache<String, Any>>(name)?.getCache(key)
+        return cacheFactory.getCache<CoherentCache<String, Any>>(name)?.getCache(key)
     }
 
     data class CacheReport(

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/DefaultCoherentCacheSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/DefaultCoherentCacheSpec.kt
@@ -20,14 +20,13 @@ import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.api.source.CacheSource
 import me.ahoo.cache.consistency.CacheEvictedEvent
 import me.ahoo.cache.consistency.CacheEvictedEventBus
+import me.ahoo.cache.consistency.CoherentCache
 import me.ahoo.cache.consistency.CoherentCacheConfiguration
-import me.ahoo.cache.consistency.DefaultCoherentCache
 import me.ahoo.cache.consistency.DefaultCoherentCacheFactory
 import me.ahoo.cache.converter.KeyConverter
 import me.ahoo.cache.distributed.DistributedCache
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
-import org.hamcrest.Matchers.nullValue
+import org.hamcrest.MatcherAssert.*
+import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.*
@@ -41,7 +40,7 @@ abstract class DefaultCoherentCacheSpec<K, V> : CacheSpec<K, V>() {
     private lateinit var clientSideCache: ClientSideCache<V>
     private lateinit var distributedCache: DistributedCache<V>
     private lateinit var cacheEvictedEventBus: CacheEvictedEventBus
-    private lateinit var coherentCache: DefaultCoherentCache<K, V>
+    private lateinit var coherentCache: CoherentCache<K, V>
     protected lateinit var cacheName: String
     protected val clientId: String = UUID.randomUUID().toString()
 


### PR DESCRIPTION
- Remove unnecessary imports of DefaultCoherentCache in various files
- Update type references from DefaultCoherentCache to CoherentCache interface
- Simplify some code constructs without changing functionality
