### PR TITLE
feat(core): Create JoinCacheProxyFactoryBean for join cache proxy creation

### DIFF
--- a/cocache-core/src/main/kotlin/me/ahoo/cache/join/proxy/DefaultJoinCacheProxyFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/join/proxy/DefaultJoinCacheProxyFactory.kt
@@ -21,10 +21,10 @@ import me.ahoo.cache.join.JoinKeyExtractorFactory
 import me.ahoo.cache.join.SimpleJoinCache
 import java.lang.reflect.Proxy
 
-class DefaultJoinProxyFactory(
+class DefaultJoinCacheProxyFactory(
     private val cacheFactory: CacheFactory,
     private val joinKeyExtractorFactory: JoinKeyExtractorFactory,
-) : JoinProxyFactory {
+) : JoinCacheProxyFactory {
     @Suppress("UNCHECKED_CAST")
     override fun <CACHE : JoinCache<*, *, *, *>> create(cacheMetadata: JoinCacheMetadata): CACHE {
         val firstCache = cacheFactory.getCache<Cache<Any, Any>>(cacheMetadata.firstCacheName)

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/join/proxy/JoinCacheProxyFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/join/proxy/JoinCacheProxyFactory.kt
@@ -11,20 +11,11 @@
  * limitations under the License.
  */
 
-package me.ahoo.cache.spring.boot.starter.auto
+package me.ahoo.cache.join.proxy
 
-import me.ahoo.cache.example.cache.UserCache
-import me.ahoo.cache.example.cache.UserExtendInfoCache
-import me.ahoo.cache.example.cache.UserExtendInfoJoinCache
-import me.ahoo.cache.spring.EnableCoCache
-import org.springframework.boot.autoconfigure.SpringBootApplication
+import me.ahoo.cache.annotation.JoinCacheMetadata
+import me.ahoo.cache.api.join.JoinCache
 
-@SpringBootApplication
-@EnableCoCache(
-    caches = [
-        UserCache::class,
-        UserExtendInfoCache::class,
-        UserExtendInfoJoinCache::class
-    ]
-)
-class EnableCoCacheConfiguration
+interface JoinCacheProxyFactory {
+    fun <CACHE : JoinCache<*, *, *, *>> create(cacheMetadata: JoinCacheMetadata): CACHE
+}

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/join/proxy/DefaultJoinCacheProxyFactoryTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/join/proxy/DefaultJoinCacheProxyFactoryTest.kt
@@ -17,7 +17,7 @@ import me.ahoo.cache.join.OrderAddress
 import me.ahoo.cache.test.CacheSpec
 import java.util.UUID
 
-class DefaultJoinProxyFactoryTest : CacheSpec<String, JoinValue<OrderAddress, String, Order>>() {
+class DefaultJoinCacheProxyFactoryTest : CacheSpec<String, JoinValue<OrderAddress, String, Order>>() {
 
     override fun createCache(): JoinCache<String, OrderAddress, String, Order> {
         val cacheFactory = mockk<CacheFactory> {
@@ -29,7 +29,7 @@ class DefaultJoinProxyFactoryTest : CacheSpec<String, JoinValue<OrderAddress, St
             every { create<OrderAddress, String>(metadata) } returns JoinKeyExtractor { it.orderId }
         }
 
-        val joinProxyFactory = DefaultJoinProxyFactory(cacheFactory, joinKeyExtractorFactory)
+        val joinProxyFactory = DefaultJoinCacheProxyFactory(cacheFactory, joinKeyExtractorFactory)
         return joinProxyFactory.create<MockJoinCache>(metadata)
     }
 

--- a/cocache-example/src/main/kotlin/me/ahoo/cache/example/cache/UserExtendInfoCache.kt
+++ b/cocache-example/src/main/kotlin/me/ahoo/cache/example/cache/UserExtendInfoCache.kt
@@ -11,11 +11,20 @@
  * limitations under the License.
  */
 
-package me.ahoo.cache.join.proxy
+package me.ahoo.cache.example.cache
 
-import me.ahoo.cache.annotation.JoinCacheMetadata
-import me.ahoo.cache.api.join.JoinCache
+import me.ahoo.cache.api.Cache
+import me.ahoo.cache.api.annotation.CoCache
+import me.ahoo.cache.api.annotation.GuavaCache
+import me.ahoo.cache.api.annotation.MissingGuardCache
+import me.ahoo.cache.example.model.UserExtendInfo
+import java.util.concurrent.TimeUnit
 
-interface JoinProxyFactory {
-    fun <CACHE : JoinCache<*, *, *, *>> create(cacheMetadata: JoinCacheMetadata): CACHE
-}
+@CoCache(keyPrefix = "userExtendInfo:")
+@GuavaCache(
+    maximumSize = 1000_000,
+    expireUnit = TimeUnit.SECONDS,
+    expireAfterAccess = 120
+)
+@MissingGuardCache(ttlSeconds = 120)
+interface UserExtendInfoCache : Cache<String, UserExtendInfo>

--- a/cocache-example/src/main/kotlin/me/ahoo/cache/example/cache/UserExtendInfoJoinCache.kt
+++ b/cocache-example/src/main/kotlin/me/ahoo/cache/example/cache/UserExtendInfoJoinCache.kt
@@ -11,20 +11,16 @@
  * limitations under the License.
  */
 
-package me.ahoo.cache.spring.boot.starter.auto
+package me.ahoo.cache.example.cache
 
-import me.ahoo.cache.example.cache.UserCache
-import me.ahoo.cache.example.cache.UserExtendInfoCache
-import me.ahoo.cache.example.cache.UserExtendInfoJoinCache
-import me.ahoo.cache.spring.EnableCoCache
-import org.springframework.boot.autoconfigure.SpringBootApplication
+import me.ahoo.cache.api.annotation.JoinCacheable
+import me.ahoo.cache.api.join.JoinCache
+import me.ahoo.cache.example.model.User
+import me.ahoo.cache.example.model.UserExtendInfo
 
-@SpringBootApplication
-@EnableCoCache(
-    caches = [
-        UserCache::class,
-        UserExtendInfoCache::class,
-        UserExtendInfoJoinCache::class
-    ]
+@JoinCacheable(
+    firstCacheName = "UserExtendInfoCache",
+    joinCacheName = "UserCache",
+    joinKeyExpression = "#{#root.userId}"
 )
-class EnableCoCacheConfiguration
+interface UserExtendInfoJoinCache : JoinCache<String, UserExtendInfo, String, User>

--- a/cocache-example/src/main/kotlin/me/ahoo/cache/example/model/UserExtendInfo.kt
+++ b/cocache-example/src/main/kotlin/me/ahoo/cache/example/model/UserExtendInfo.kt
@@ -11,20 +11,6 @@
  * limitations under the License.
  */
 
-package me.ahoo.cache.spring.boot.starter.auto
+package me.ahoo.cache.example.model
 
-import me.ahoo.cache.example.cache.UserCache
-import me.ahoo.cache.example.cache.UserExtendInfoCache
-import me.ahoo.cache.example.cache.UserExtendInfoJoinCache
-import me.ahoo.cache.spring.EnableCoCache
-import org.springframework.boot.autoconfigure.SpringBootApplication
-
-@SpringBootApplication
-@EnableCoCache(
-    caches = [
-        UserCache::class,
-        UserExtendInfoCache::class,
-        UserExtendInfoJoinCache::class
-    ]
-)
-class EnableCoCacheConfiguration
+data class UserExtendInfo(val id: String, val userId: String)

--- a/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfiguration.kt
+++ b/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfiguration.kt
@@ -20,8 +20,8 @@ import me.ahoo.cache.consistency.DefaultCoherentCacheFactory
 import me.ahoo.cache.converter.KeyConverterFactory
 import me.ahoo.cache.distributed.DistributedCacheFactory
 import me.ahoo.cache.join.JoinKeyExtractorFactory
-import me.ahoo.cache.join.proxy.DefaultJoinProxyFactory
-import me.ahoo.cache.join.proxy.JoinProxyFactory
+import me.ahoo.cache.join.proxy.DefaultJoinCacheProxyFactory
+import me.ahoo.cache.join.proxy.JoinCacheProxyFactory
 import me.ahoo.cache.proxy.CacheProxyFactory
 import me.ahoo.cache.proxy.DefaultCacheProxyFactory
 import me.ahoo.cache.source.CacheSourceFactory
@@ -154,11 +154,11 @@ class CoCacheAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun joinProxyFactory(
+    fun joinCacheProxyFactory(
         cacheFactory: CacheFactory,
         joinKeyExtractorFactory: JoinKeyExtractorFactory
-    ): JoinProxyFactory {
-        return DefaultJoinProxyFactory(cacheFactory, joinKeyExtractorFactory)
+    ): JoinCacheProxyFactory {
+        return DefaultJoinCacheProxyFactory(cacheFactory, joinKeyExtractorFactory)
     }
 
     @Configuration

--- a/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfigurationTest.kt
+++ b/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfigurationTest.kt
@@ -16,6 +16,7 @@ package me.ahoo.cache.spring.boot.starter
 import me.ahoo.cache.CacheFactory
 import me.ahoo.cache.consistency.CacheEvictedEventBus
 import me.ahoo.cache.example.cache.UserCache
+import me.ahoo.cache.example.cache.UserExtendInfoJoinCache
 import me.ahoo.cache.spring.boot.starter.auto.EnableCoCacheConfiguration
 import me.ahoo.cache.spring.boot.starter.customize.EnableCoCacheConfigurationWithCustomize
 import me.ahoo.cache.spring.boot.starter.customize.UserExpCache
@@ -50,6 +51,7 @@ internal class CoCacheAutoConfigurationTest {
                     .hasSingleBean(UserCache::class.java)
 
                 context.getBean(UserCache::class.java)
+                context.getBean(UserExtendInfoJoinCache::class.java)
             }
     }
 

--- a/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfigurationTest.kt
+++ b/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfigurationTest.kt
@@ -19,6 +19,8 @@ import me.ahoo.cache.example.cache.UserCache
 import me.ahoo.cache.example.cache.UserExtendInfoJoinCache
 import me.ahoo.cache.spring.boot.starter.auto.EnableCoCacheConfiguration
 import me.ahoo.cache.spring.boot.starter.customize.EnableCoCacheConfigurationWithCustomize
+import me.ahoo.cache.spring.boot.starter.customize.MockUserExtendInfoJoinCache
+import me.ahoo.cache.spring.boot.starter.customize.MockUserExtendInfoJoinCacheUseNameSuffix
 import me.ahoo.cache.spring.boot.starter.customize.UserExpCache
 import me.ahoo.cache.spring.boot.starter.customize.UserKeyCache
 import me.ahoo.cache.spring.boot.starter.customize.UserPlaceholderCache
@@ -76,6 +78,8 @@ internal class CoCacheAutoConfigurationTest {
                 context.getBean(UserExpCache::class.java)
                 context.getBean(UserPlaceholderCache::class.java)
                 context.getBean(UserKeyCache::class.java)
+                context.getBean(MockUserExtendInfoJoinCache::class.java)
+                context.getBean(MockUserExtendInfoJoinCacheUseNameSuffix::class.java)
             }
     }
 

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/SpringCacheFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/SpringCacheFactory.kt
@@ -27,7 +27,7 @@ class SpringCacheFactory(private val beanFactory: ListableBeanFactory) : CacheFa
     @Suppress("UNCHECKED_CAST", "SwallowedException")
     override fun <CACHE : Cache<*, *>> getCache(cacheName: String, cacheType: Class<*>): CACHE? {
         return try {
-            beanFactory.getBean(cacheName, cacheType::class.java) as CACHE
+            beanFactory.getBean(cacheName, cacheType) as CACHE
         } catch (error: NoSuchBeanDefinitionException) {
             null
         }

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/join/JoinCacheProxyFactoryBean.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/join/JoinCacheProxyFactoryBean.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cache.spring.join
+
+import me.ahoo.cache.annotation.JoinCacheMetadata
+import me.ahoo.cache.api.join.JoinCache
+import me.ahoo.cache.join.proxy.JoinCacheProxyFactory
+import org.springframework.beans.factory.FactoryBean
+import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationContextAware
+
+class JoinCacheProxyFactoryBean(private val cacheMetadata: JoinCacheMetadata) :
+    FactoryBean<JoinCache<Any, Any, Any, Any>>,
+    ApplicationContextAware {
+    private lateinit var appContext: ApplicationContext
+    override fun setApplicationContext(applicationContext: ApplicationContext) {
+        this.appContext = applicationContext
+    }
+
+    override fun getObject(): JoinCache<Any, Any, Any, Any> {
+        val cacheProxyFactory = appContext.getBean(JoinCacheProxyFactory::class.java)
+        return cacheProxyFactory.create(cacheMetadata)
+    }
+
+    override fun getObjectType(): Class<*> {
+        return cacheMetadata.proxyInterface.java
+    }
+}


### PR DESCRIPTION
- Rename JoinProxyFactory to JoinCacheProxyFactory
- Rename DefaultJoinProxyFactory to DefaultJoinCacheProxyFactory
- Update related test classes
- Add support for join cache in EnableCoCache annotation
- Create JoinCacheProxyFactoryBean for join cache proxy creation
- Add UserExtendInfoCache and UserExtendInfoJoinCache examples
