### PR TITLE
feat(core): support get Cache by key and value type

### DIFF
--- a/cocache-core/src/main/kotlin/me/ahoo/cache/CacheFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/CacheFactory.kt
@@ -22,4 +22,6 @@ interface CacheFactory {
     }
 
     fun <CACHE : Cache<*, *>> getCache(cacheName: String, cacheType: Class<*>): CACHE?
+
+    fun <CACHE : Cache<*, *>> getCache(keyType: Class<*>, valueType: Class<*>): CACHE?
 }

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/JoinCacheMetadataParser.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/JoinCacheMetadataParser.kt
@@ -43,12 +43,6 @@ object JoinCacheMetadataParser {
         val firstValueType = superCacheType.getCacheGenericsType(1)
         val joinKeyType = superCacheType.getCacheGenericsType(2)
         val joinValueType = superCacheType.getCacheGenericsType(3)
-        require(joinCacheAnnotation.firstCacheName.isNotBlank()) {
-            "[${proxyInterface.jvmName}] JoinCacheable.firstCacheName must be not blank."
-        }
-        require(joinCacheAnnotation.joinCacheName.isNotBlank()) {
-            "[${proxyInterface.jvmName}] JoinCacheable.joinCacheName must be not blank."
-        }
         if (joinCacheAnnotation.joinKeyExpression.isNotBlank()) {
             require(joinKeyType == String::class) {
                 "[${proxyInterface.jvmName}] JoinCacheable.joinKeyExpression must be blank when joinKeyType is not String."

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/join/proxy/DefaultJoinCacheProxyFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/join/proxy/DefaultJoinCacheProxyFactory.kt
@@ -27,9 +27,17 @@ class DefaultJoinCacheProxyFactory(
 ) : JoinCacheProxyFactory {
     @Suppress("UNCHECKED_CAST")
     override fun <CACHE : JoinCache<*, *, *, *>> create(cacheMetadata: JoinCacheMetadata): CACHE {
-        val firstCache = cacheFactory.getCache<Cache<Any, Any>>(cacheMetadata.firstCacheName)
+        val firstCache = getCache(
+            cacheName = cacheMetadata.firstCacheName,
+            keyType = cacheMetadata.firstKeyType.java,
+            valueType = cacheMetadata.firstValueType.java
+        )
         requireNotNull(firstCache)
-        val joinCache = cacheFactory.getCache<Cache<Any, Any>>(cacheMetadata.joinCacheName)
+        val joinCache = getCache(
+            cacheName = cacheMetadata.joinCacheName,
+            keyType = cacheMetadata.joinKeyType.java,
+            valueType = cacheMetadata.joinValueType.java
+        )
         requireNotNull(joinCache)
 
         val joinKeyExtractor = joinKeyExtractorFactory.create<Any, Any>(cacheMetadata)
@@ -45,5 +53,12 @@ class DefaultJoinCacheProxyFactory(
             ),
             invocationHandler
         ) as CACHE
+    }
+
+    private fun getCache(cacheName: String, keyType: Class<*>, valueType: Class<*>): Cache<Any, Any>? {
+        if (cacheName.isNotBlank()) {
+            return cacheFactory.getCache(cacheName)
+        }
+        return cacheFactory.getCache(keyType, valueType)
     }
 }

--- a/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfigurationTest.kt
+++ b/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfigurationTest.kt
@@ -19,6 +19,7 @@ import me.ahoo.cache.example.cache.UserCache
 import me.ahoo.cache.example.cache.UserExtendInfoJoinCache
 import me.ahoo.cache.spring.boot.starter.auto.EnableCoCacheConfiguration
 import me.ahoo.cache.spring.boot.starter.customize.EnableCoCacheConfigurationWithCustomize
+import me.ahoo.cache.spring.boot.starter.customize.MockJoinMainCache
 import me.ahoo.cache.spring.boot.starter.customize.MockUserExtendInfoJoinCache
 import me.ahoo.cache.spring.boot.starter.customize.MockUserExtendInfoJoinCacheUseNameSuffix
 import me.ahoo.cache.spring.boot.starter.customize.UserExpCache
@@ -80,6 +81,7 @@ internal class CoCacheAutoConfigurationTest {
                 context.getBean(UserKeyCache::class.java)
                 context.getBean(MockUserExtendInfoJoinCache::class.java)
                 context.getBean(MockUserExtendInfoJoinCacheUseNameSuffix::class.java)
+                context.getBean(MockJoinMainCache::class.java)
             }
     }
 

--- a/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/customize/EnableCoCacheConfigurationWithCustomize.kt
+++ b/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/customize/EnableCoCacheConfigurationWithCustomize.kt
@@ -40,7 +40,10 @@ import org.springframework.context.annotation.Bean
         UserKeyCache::class,
         UserExtendInfoCache::class,
         MockUserExtendInfoJoinCache::class,
-        MockUserExtendInfoJoinCacheUseNameSuffix::class
+        MockUserExtendInfoJoinCacheUseNameSuffix::class,
+        MainDataCache::class,
+        JoinDataCache::class,
+        MockJoinMainCache::class
     ]
 )
 class EnableCoCacheConfigurationWithCustomize {
@@ -96,3 +99,14 @@ interface MockUserExtendInfoJoinCache : JoinCache<String, UserExtendInfo, String
     joinCacheName = "UserCache"
 )
 interface MockUserExtendInfoJoinCacheUseNameSuffix : JoinCache<String, UserExtendInfo, String, User>
+
+interface MainData
+interface JoinData
+
+interface MainDataCache : Cache<String, MainData>
+interface JoinDataCache : Cache<String, JoinData>
+
+@JoinCacheable(
+    joinKeyExpression = "#{#root.mainId}"
+)
+interface MockJoinMainCache : JoinCache<String, MainData, String, JoinData>

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/SpringCacheFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/SpringCacheFactory.kt
@@ -17,6 +17,7 @@ import me.ahoo.cache.CacheFactory
 import me.ahoo.cache.api.Cache
 import org.springframework.beans.factory.ListableBeanFactory
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
+import org.springframework.core.ResolvableType
 
 class SpringCacheFactory(private val beanFactory: ListableBeanFactory) : CacheFactory {
     override val caches: Map<String, Cache<*, *>>
@@ -29,6 +30,18 @@ class SpringCacheFactory(private val beanFactory: ListableBeanFactory) : CacheFa
         return try {
             beanFactory.getBean(cacheName, cacheType) as CACHE
         } catch (error: NoSuchBeanDefinitionException) {
+            null
+        }
+    }
+
+    override fun <CACHE : Cache<*, *>> getCache(keyType: Class<*>, valueType: Class<*>): CACHE? {
+        val cacheType = ResolvableType.forClassWithGenerics(
+            Cache::class.java,
+            keyType,
+            valueType
+        )
+        val provider = beanFactory.getBeanProvider<CACHE>(cacheType)
+        return provider.getIfAvailable {
             null
         }
     }


### PR DESCRIPTION
- Add new method in CacheFactory to get Cache by key and value type
- Implement the new method in SpringCacheFactory
- Update DefaultJoinCacheProxyFactory to use the new method
- Add test cases for the new functionality
