### PR TITLE
refactor(JoinCacheMetadataParser): relax @JoinCacheable annotation requirement

### DIFF
--- a/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/JoinCacheMetadataParser.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/JoinCacheMetadataParser.kt
@@ -14,7 +14,6 @@
 package me.ahoo.cache.annotation
 
 import me.ahoo.cache.annotation.CoCacheMetadataParser.getCacheGenericsType
-import me.ahoo.cache.api.Cache
 import me.ahoo.cache.api.annotation.JoinCacheable
 import me.ahoo.cache.api.join.JoinCache
 import kotlin.reflect.KClass
@@ -27,14 +26,11 @@ object JoinCacheMetadataParser {
      *
      * @param proxyInterface 必须继承 `JoinCache` 接口，必须是接口
      */
-    fun parse(proxyInterface: KClass<out Cache<*, *>>): JoinCacheMetadata {
+    fun parse(proxyInterface: KClass<out JoinCache<*, *, *, *>>): JoinCacheMetadata {
         require(proxyInterface.java.isInterface) {
             "${proxyInterface.jvmName} must be interface."
         }
-        val joinCacheAnnotation = proxyInterface.findAnnotation<JoinCacheable>()
-        requireNotNull(joinCacheAnnotation) {
-            "${proxyInterface.jvmName} must be marked with @JoinCacheable"
-        }
+        val joinCacheAnnotation = proxyInterface.findAnnotation<JoinCacheable>() ?: JoinCacheable()
         // 获取继承的 JoinCache<K,V> 中 V 的具体类型
         val superCacheType = proxyInterface.supertypes.first {
             it.classifier == JoinCache::class

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/annotation/JoinCacheMetadataParserTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/annotation/JoinCacheMetadataParserTest.kt
@@ -1,10 +1,13 @@
 package me.ahoo.cache.annotation
 
+import me.ahoo.cache.api.annotation.JoinCacheable
+import me.ahoo.cache.api.join.JoinCache
 import me.ahoo.cache.join.MockJoinCache
 import me.ahoo.cache.join.Order
 import me.ahoo.cache.join.OrderAddress
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.*
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class JoinCacheMetadataParserTest {
@@ -22,4 +25,39 @@ class JoinCacheMetadataParserTest {
         assertThat(metadata.joinKeyType, equalTo(String::class))
         assertThat(metadata.joinValueType, equalTo(Order::class))
     }
+
+    @Test
+    fun parseIfNotInterface() {
+        Assertions.assertThrows(IllegalArgumentException::class.java) {
+            joinCacheMetadata<NotJoinInterface>()
+        }
+    }
+
+    @Test
+    fun parseIfNotAnnotation() {
+        val metadata = joinCacheMetadata<NotJoinAnnotation>()
+        assertThat(metadata.proxyInterface, equalTo(NotJoinAnnotation::class))
+        assertThat(metadata.name, equalTo(""))
+        assertThat(metadata.cacheName, equalTo("NotJoinAnnotation"))
+        assertThat(metadata.firstCacheName, equalTo(""))
+        assertThat(metadata.joinCacheName, equalTo(""))
+        assertThat(metadata.joinKeyExpression, equalTo(""))
+        assertThat(metadata.firstKeyType, equalTo(String::class))
+        assertThat(metadata.firstValueType, equalTo(String::class))
+        assertThat(metadata.joinKeyType, equalTo(String::class))
+        assertThat(metadata.joinValueType, equalTo(String::class))
+    }
+
+    @Test
+    fun parseIfExpNotJoinStringKey() {
+        Assertions.assertThrows(IllegalArgumentException::class.java) {
+            joinCacheMetadata<ExpNotJoinStringKey>()
+        }
+    }
 }
+
+abstract class NotJoinInterface : JoinCache<String, String, String, String>
+interface NotJoinAnnotation : JoinCache<String, String, String, String>
+
+@JoinCacheable(joinKeyExpression = "#{#root}")
+interface ExpNotJoinStringKey : JoinCache<String, String, JoinCacheMetadataParserTest, String>


### PR DESCRIPTION
- Remove mandatory @JoinCacheable annotation check for JoinCache interfaces
- Update parse function to use default JoinCacheable values if not present
- Add test cases for scenarios without @JoinCacheable annotation
- Improve error handling and validation for invalid JoinCache interfaces