### PR TITLE
test(cocache-core): enhance ExpKeyConverterTest with object key conversion

### DIFF
--- a/cocache-core/src/test/kotlin/me/ahoo/cache/converter/ExpKeyConverterTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/converter/ExpKeyConverterTest.kt
@@ -22,11 +22,23 @@ import org.junit.jupiter.api.Test
  */
 internal class ExpKeyConverterTest {
     @Test
-    fun asString() {
+    fun toStringKey() {
         val prefix = "prefix:"
         val expKeyConverter = ExpKeyConverter<String>(prefix, "#{#root}")
         Assertions.assertEquals(prefix, expKeyConverter.keyPrefix)
         val actual = expKeyConverter.toStringKey("asString")
         Assertions.assertEquals(prefix + "asString", actual)
     }
+
+    @Test
+    fun toStringKeyIfObject() {
+        val prefix = "prefix:"
+        val expKeyConverter = ExpKeyConverter<BrandNameIndexKey>(prefix, "#{tenantId}:#{name}")
+        Assertions.assertEquals(prefix, expKeyConverter.keyPrefix)
+        val brandNameIndexKey = BrandNameIndexKey("tenantId", "name")
+        val actual = expKeyConverter.toStringKey(brandNameIndexKey)
+        Assertions.assertEquals(prefix + "tenantId:name", actual)
+    }
 }
+
+data class BrandNameIndexKey(val tenantId: String, val name: String)


### PR DESCRIPTION
- Add new test case for converting object keys
- Introduce BrandNameIndexKey data class for testing
- Update existing test case to use more descriptive method name