### PR TITLE
build(kotlin): enable java parameters for kotlin compiler 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,9 @@ configure(libraryProjects) {
             javaParameters = true
         }
     }
+    tasks.withType<JavaCompile> {
+        options.compilerArgs.addAll(listOf("-parameters"))
+    }
     tasks.withType<Test> {
         useJUnitPlatform()
         testLogging {
@@ -100,9 +103,6 @@ configure(libraryProjects) {
         }
         // fix logging missing code for JacocoPlugin
         jvmArgs = listOf("-Dlogback.configurationFile=${rootProject.rootDir}/config/logback.xml")
-    }
-    tasks.withType<JavaCompile> {
-        options.compilerArgs.addAll(listOf("-parameters"))
     }
     dependencies {
         api(platform(dependenciesProject))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,6 +90,7 @@ configure(libraryProjects) {
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         compilerOptions {
             freeCompilerArgs = listOf("-Xjsr305=strict", "-Xjvm-default=all-compatibility")
+            javaParameters = true
         }
     }
     tasks.withType<Test> {


### PR DESCRIPTION
- Add 'javaParameters = true' to Kotlin compiler options
- This change improves compatibility with Java platforms