### PR TITLE
fix(cocache-core): implement fine-grained locking to prevent cache breakdown

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,6 +109,8 @@ configure(libraryProjects) {
         detektPlugins(platform(dependenciesProject))
         implementation("org.slf4j:slf4j-api")
         testImplementation("ch.qos.logback:logback-classic")
+        testImplementation("org.junit.jupiter:junit-jupiter-api")
+        testImplementation("org.junit.jupiter:junit-jupiter-params")
         testImplementation("org.hamcrest:hamcrest")
         testImplementation("io.mockk:mockk") {
             exclude(group = "org.slf4j", module = "slf4j-api")

--- a/cocache-test/build.gradle.kts
+++ b/cocache-test/build.gradle.kts
@@ -4,4 +4,5 @@ dependencies {
     api(project(":cocache-core"))
     api("org.hamcrest:hamcrest")
     implementation("org.junit.jupiter:junit-jupiter-api")
+    implementation("org.junit.jupiter:junit-jupiter-params")
 }


### PR DESCRIPTION
- Add ConcurrentHashMap to store locks for individual cache keys
- Implement getLock() and releaseLock() methods for managing locks
- Modify getCache() method to use fine-grained locking for concurrent requests
- Add unit test to verify cache breakdown prevention under high concurrency
- Update build.gradle.kts files to include JUnit Jupiter Params dependency