### PR TITLE
build(deps): update dependencies and move kotlin-logging-jvm

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,7 +108,6 @@ configure(libraryProjects) {
         api(platform(dependenciesProject))
         detektPlugins(platform(dependenciesProject))
         implementation("org.slf4j:slf4j-api")
-        implementation("io.github.oshai:kotlin-logging-jvm")
         testImplementation("ch.qos.logback:logback-classic")
         testImplementation("org.junit.jupiter:junit-jupiter-api")
         testImplementation("org.junit.jupiter:junit-jupiter-params")

--- a/cocache-core/build.gradle.kts
+++ b/cocache-core/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
     api("me.ahoo.cosid:cosid-core")
     implementation(kotlin("reflect"))
     implementation("com.google.guava:guava")
+    api("io.github.oshai:kotlin-logging-jvm")
     implementation("org.springframework:spring-expression")
     testImplementation(project(":cocache-test"))
 }


### PR DESCRIPTION
- Move kotlin-logging-jvm from build.gradle.kts to cocache-core/build.gradle.kts
- Remove slf4j-api from cocache-core dependencies
