### PR TITLE
feat(cache): register cache metadata as bean and enhance client-side cache customization

### DIFF
--- a/cocache-example/src/main/kotlin/me/ahoo/cache/example/config/UserCacheConfiguration.kt
+++ b/cocache-example/src/main/kotlin/me/ahoo/cache/example/config/UserCacheConfiguration.kt
@@ -12,18 +12,23 @@
  */
 package me.ahoo.cache.example.config
 
+import me.ahoo.cache.annotation.CoCacheMetadata
 import me.ahoo.cache.api.source.CacheSource
 import me.ahoo.cache.api.client.ClientSideCache
 import me.ahoo.cache.client.MapClientSideCache
 import me.ahoo.cache.example.model.User
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 class UserCacheConfiguration {
     @Bean
-    fun customizeUserClientSideCache(): ClientSideCache<User> {
-        return MapClientSideCache()
+    fun customizeUserClientSideCache(
+        @Qualifier("UserCache.CacheMetadata")
+        cacheMetadata: CoCacheMetadata
+    ): ClientSideCache<User> {
+        return MapClientSideCache(ttl = cacheMetadata.ttl, ttlAmplitude = cacheMetadata.ttlAmplitude)
     }
 
     @Bean

--- a/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfigurationTest.kt
+++ b/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfigurationTest.kt
@@ -52,6 +52,7 @@ internal class CoCacheAutoConfigurationTest {
                     .hasSingleBean(CacheEvictedEventBus::class.java)
                     .hasSingleBean(CacheFactory::class.java)
                     .hasSingleBean(UserCache::class.java)
+                    .hasBean("UserCache.CacheMetadata")
 
                 context.getBean(UserCache::class.java)
                 context.getBean(UserExtendInfoJoinCache::class.java)

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/EnableCoCacheRegistrar.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/EnableCoCacheRegistrar.kt
@@ -31,11 +31,21 @@ import kotlin.reflect.KClass
 class EnableCoCacheRegistrar : ImportBeanDefinitionRegistrar {
     companion object {
         private val log = LoggerFactory.getLogger(EnableCoCacheRegistrar::class.java)
+        const val CACHE_METADATA_SUFFIX = ".CacheMetadata"
+    }
+
+    private fun BeanDefinitionRegistry.registerCacheMetadata(cacheMetadata: CoCacheMetadata) {
+        val metadataName = "${cacheMetadata.cacheName}$CACHE_METADATA_SUFFIX"
+        val metadataBeanDefinition = BeanDefinitionBuilder.genericBeanDefinition(CoCacheMetadata::class.java) {
+            cacheMetadata
+        }
+        registerBeanDefinition(metadataName, metadataBeanDefinition.beanDefinition)
     }
 
     override fun registerBeanDefinitions(importingClassMetadata: AnnotationMetadata, registry: BeanDefinitionRegistry) {
         val cacheMetadataList = resolveCacheMetadataList(importingClassMetadata)
         cacheMetadataList.forEach { cacheMetadata ->
+            registry.registerCacheMetadata(cacheMetadata)
             val beanDefinitionBuilder = BeanDefinitionBuilder.genericBeanDefinition(CacheProxyFactoryBean::class.java)
             beanDefinitionBuilder.addConstructorArgValue(cacheMetadata)
             beanDefinitionBuilder.setPrimary(true)


### PR DESCRIPTION
- Register cache metadata as a bean in the application context
- Update client-side cache customization to use cache metadata
- Add test to verify cache metadata bean registration

