### PR TITLE
ci: disable push event trigger for GitHub Actions workflows

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,5 @@
 name: Codecov
-on: [ pull_request ]
+on: [ push, pull_request ]
 jobs:
   codecov:
     name: Codecov

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,5 @@
 name: Codecov
-on: [ push, pull_request ]
+on: [ pull_request ]
 jobs:
   codecov:
     name: Codecov

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,7 +12,7 @@
 #
 
 name: Integration Test
-on: [ push, pull_request ]
+on: [ pull_request ]
 jobs:
   cocache-core-test:
     name: CoCache Core Test


### PR DESCRIPTION
- Update Codecov workflow to only run on pull_request events
- Update Integration Test workflow to only run on pull_request events

