### PR TITLE
feat(core): support KType for cache generics

### DIFF
--- a/cocache-core/build.gradle.kts
+++ b/cocache-core/build.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
     api(project(":cocache-api"))
     api("me.ahoo.cosid:cosid-core")
-    implementation(kotlin("reflect"))
+    api(kotlin("reflect"))
     implementation("com.google.guava:guava")
     api("io.github.oshai:kotlin-logging-jvm")
     implementation("org.springframework:spring-expression")

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/CacheFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/CacheFactory.kt
@@ -14,6 +14,7 @@
 package me.ahoo.cache
 
 import me.ahoo.cache.api.Cache
+import kotlin.reflect.KType
 
 interface CacheFactory {
     val caches: Map<String, Cache<*, *>>
@@ -23,5 +24,5 @@ interface CacheFactory {
 
     fun <CACHE : Cache<*, *>> getCache(cacheName: String, cacheType: Class<*>): CACHE?
 
-    fun <CACHE : Cache<*, *>> getCache(keyType: Class<*>, valueType: Class<*>): CACHE?
+    fun <CACHE : Cache<*, *>> getCache(keyType: KType, valueType: KType): CACHE?
 }

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/CoCacheMetadata.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/CoCacheMetadata.kt
@@ -15,6 +15,7 @@ package me.ahoo.cache.annotation
 
 import me.ahoo.cache.TtlConfiguration
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 data class CoCacheMetadata(
     override val proxyInterface: KClass<*>,
@@ -23,8 +24,8 @@ data class CoCacheMetadata(
     val keyExpression: String,
     override val ttl: Long,
     override val ttlAmplitude: Long,
-    val keyType: KClass<*>,
-    val valueType: KClass<*>
+    val keyType: KType,
+    val valueType: KType
 ) : ComputedNamedCache, TtlConfiguration {
     override val cacheName: String = name.ifBlank {
         proxyInterface.simpleName!!

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParser.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParser.kt
@@ -52,8 +52,8 @@ object CoCacheMetadataParser {
         )
     }
 
-    fun KType.getCacheGenericsType(index: Int): KClass<*> {
-        return arguments[index].type?.classifier as KClass<*>
+    fun KType.getCacheGenericsType(index: Int): KType {
+        return requireNotNull(arguments[index].type)
     }
 }
 

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/JoinCacheMetadata.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/JoinCacheMetadata.kt
@@ -14,6 +14,7 @@
 package me.ahoo.cache.annotation
 
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 data class JoinCacheMetadata(
     override val proxyInterface: KClass<*>,
@@ -21,8 +22,8 @@ data class JoinCacheMetadata(
     val firstCacheName: String,
     val joinCacheName: String,
     val joinKeyExpression: String,
-    val firstKeyType: KClass<*>,
-    val firstValueType: KClass<*>,
-    val joinKeyType: KClass<*>,
-    val joinValueType: KClass<*>
+    val firstKeyType: KType,
+    val firstValueType: KType,
+    val joinKeyType: KType,
+    val joinValueType: KType
 ) : ComputedNamedCache

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/JoinCacheMetadataParser.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/annotation/JoinCacheMetadataParser.kt
@@ -40,7 +40,7 @@ object JoinCacheMetadataParser {
         val joinKeyType = superCacheType.getCacheGenericsType(2)
         val joinValueType = superCacheType.getCacheGenericsType(3)
         if (joinCacheAnnotation.joinKeyExpression.isNotBlank()) {
-            require(joinKeyType == String::class) {
+            require(joinKeyType.classifier == String::class) {
                 "[${proxyInterface.jvmName}] JoinCacheable.joinKeyExpression must be blank when joinKeyType is not String."
             }
         }

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/join/proxy/DefaultJoinCacheProxyFactory.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/join/proxy/DefaultJoinCacheProxyFactory.kt
@@ -20,6 +20,7 @@ import me.ahoo.cache.api.join.JoinCache
 import me.ahoo.cache.join.JoinKeyExtractorFactory
 import me.ahoo.cache.join.SimpleJoinCache
 import java.lang.reflect.Proxy
+import kotlin.reflect.KType
 
 class DefaultJoinCacheProxyFactory(
     private val cacheFactory: CacheFactory,
@@ -29,14 +30,14 @@ class DefaultJoinCacheProxyFactory(
     override fun <CACHE : JoinCache<*, *, *, *>> create(cacheMetadata: JoinCacheMetadata): CACHE {
         val firstCache = getCache(
             cacheName = cacheMetadata.firstCacheName,
-            keyType = cacheMetadata.firstKeyType.java,
-            valueType = cacheMetadata.firstValueType.java
+            keyType = cacheMetadata.firstKeyType,
+            valueType = cacheMetadata.firstValueType
         )
         requireNotNull(firstCache)
         val joinCache = getCache(
             cacheName = cacheMetadata.joinCacheName,
-            keyType = cacheMetadata.joinKeyType.java,
-            valueType = cacheMetadata.joinValueType.java
+            keyType = cacheMetadata.joinKeyType,
+            valueType = cacheMetadata.joinValueType
         )
         requireNotNull(joinCache)
 
@@ -55,7 +56,7 @@ class DefaultJoinCacheProxyFactory(
         ) as CACHE
     }
 
-    private fun getCache(cacheName: String, keyType: Class<*>, valueType: Class<*>): Cache<Any, Any>? {
+    private fun getCache(cacheName: String, keyType: KType, valueType: KType): Cache<Any, Any>? {
         if (cacheName.isNotBlank()) {
             return cacheFactory.getCache(cacheName)
         }

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParserTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/annotation/CoCacheMetadataParserTest.kt
@@ -4,8 +4,7 @@ import me.ahoo.cache.ComputedCache
 import me.ahoo.cache.api.Cache
 import me.ahoo.cache.api.annotation.CoCache
 import me.ahoo.cache.proxy.MockCacheWithKeyExpression
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -14,31 +13,31 @@ class CoCacheMetadataParserTest {
     @Test
     fun parse() {
         val metadata = coCacheMetadata<MockCache>()
-        assertThat(metadata.proxyInterface, equalTo(MockCache::class))
-        assertThat(metadata.name, equalTo(""))
-        assertThat(metadata.keyPrefix, equalTo(""))
-        assertThat(metadata.keyType, equalTo(String::class))
-        assertThat(metadata.valueType, equalTo(CoCacheMetadataParserTest::class))
+        metadata.proxyInterface.assert().isEqualTo(MockCache::class)
+        metadata.name.assert().isEqualTo("")
+        metadata.keyPrefix.assert().isEqualTo("")
+        metadata.keyType.classifier.assert().isEqualTo(String::class)
+        metadata.valueType.classifier.assert().isEqualTo(CoCacheMetadataParserTest::class)
     }
 
     @Test
     fun parseComputedCache() {
         val metadata = coCacheMetadata<MockComputedCache>()
-        assertThat(metadata.proxyInterface, equalTo(MockComputedCache::class))
-        assertThat(metadata.name, equalTo(""))
-        assertThat(metadata.keyPrefix, equalTo(""))
-        assertThat(metadata.keyType, equalTo(String::class))
-        assertThat(metadata.valueType, equalTo(CoCacheMetadataParserTest::class))
+        metadata.proxyInterface.assert().isEqualTo(MockComputedCache::class)
+        metadata.name.assert().isEqualTo("")
+        metadata.keyPrefix.assert().isEqualTo("")
+        metadata.keyType.classifier.assert().isEqualTo(String::class)
+        metadata.valueType.classifier.assert().isEqualTo(CoCacheMetadataParserTest::class)
     }
 
     @Test
     fun parseWithKeyExp() {
         val metadata = coCacheMetadata<MockCacheWithKeyExpression>()
-        assertThat(metadata.proxyInterface, equalTo(MockCacheWithKeyExpression::class))
-        assertThat(metadata.name, equalTo(""))
-        assertThat(metadata.keyPrefix, equalTo("prefix:"))
-        assertThat(metadata.keyExpression, equalTo("#{#root}"))
-        assertThat(metadata.valueType, equalTo(String::class))
+        metadata.proxyInterface.assert().isEqualTo(MockCacheWithKeyExpression::class)
+        metadata.keyType.classifier.assert().isEqualTo(String::class)
+        metadata.valueType.classifier.assert().isEqualTo(String::class)
+        metadata.keyExpression.assert().isEqualTo("#{#root}")
+        metadata.keyPrefix.assert().isEqualTo("prefix:")
     }
 
     @Test
@@ -48,8 +47,22 @@ class CoCacheMetadataParserTest {
         }
     }
 
+    @Test
+    fun parseGenericValueCache() {
+        val metadata = coCacheMetadata<MockGenericValueCache>()
+        metadata.proxyInterface.assert().isEqualTo(MockGenericValueCache::class)
+        metadata.name.assert().isEqualTo("")
+        metadata.keyPrefix.assert().isEqualTo("")
+        metadata.keyType.classifier.assert().isEqualTo(String::class)
+        metadata.valueType.classifier.assert().isEqualTo(List::class)
+        metadata.valueType.arguments[0].type!!.classifier.assert().isEqualTo(CoCacheMetadataParserTest::class)
+    }
+
     @CoCache
     interface MockCache : Cache<String, CoCacheMetadataParserTest>
+
+    @CoCache
+    interface MockGenericValueCache : Cache<String, List<CoCacheMetadataParserTest>>
 
     @CoCache
     interface MockComputedCache : ComputedCache<String, CoCacheMetadataParserTest>

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/annotation/JoinCacheMetadataParserTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/annotation/JoinCacheMetadataParserTest.kt
@@ -5,8 +5,7 @@ import me.ahoo.cache.api.join.JoinCache
 import me.ahoo.cache.join.MockJoinCache
 import me.ahoo.cache.join.Order
 import me.ahoo.cache.join.OrderAddress
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -14,16 +13,16 @@ class JoinCacheMetadataParserTest {
     @Test
     fun parse() {
         val metadata = joinCacheMetadata<MockJoinCache>()
-        assertThat(metadata.proxyInterface, equalTo(MockJoinCache::class))
-        assertThat(metadata.name, equalTo(""))
-        assertThat(metadata.cacheName, equalTo("MockJoinCache"))
-        assertThat(metadata.firstCacheName, equalTo("OrderAddress"))
-        assertThat(metadata.joinCacheName, equalTo("Order"))
-        assertThat(metadata.joinKeyExpression, equalTo(""))
-        assertThat(metadata.firstKeyType, equalTo(String::class))
-        assertThat(metadata.firstValueType, equalTo(OrderAddress::class))
-        assertThat(metadata.joinKeyType, equalTo(String::class))
-        assertThat(metadata.joinValueType, equalTo(Order::class))
+        metadata.proxyInterface.assert().isEqualTo(MockJoinCache::class)
+        metadata.name.assert().isEqualTo("")
+        metadata.cacheName.assert().isEqualTo("MockJoinCache")
+        metadata.firstCacheName.assert().isEqualTo("OrderAddress")
+        metadata.joinCacheName.assert().isEqualTo("Order")
+        metadata.joinKeyExpression.assert().isEqualTo("")
+        metadata.firstKeyType.classifier.assert().isEqualTo(String::class)
+        metadata.firstValueType.classifier.assert().isEqualTo(OrderAddress::class)
+        metadata.joinKeyType.classifier.assert().isEqualTo(String::class)
+        metadata.joinValueType.classifier.assert().isEqualTo(Order::class)
     }
 
     @Test
@@ -36,16 +35,16 @@ class JoinCacheMetadataParserTest {
     @Test
     fun parseIfNotAnnotation() {
         val metadata = joinCacheMetadata<NotJoinAnnotation>()
-        assertThat(metadata.proxyInterface, equalTo(NotJoinAnnotation::class))
-        assertThat(metadata.name, equalTo(""))
-        assertThat(metadata.cacheName, equalTo("NotJoinAnnotation"))
-        assertThat(metadata.firstCacheName, equalTo(""))
-        assertThat(metadata.joinCacheName, equalTo(""))
-        assertThat(metadata.joinKeyExpression, equalTo(""))
-        assertThat(metadata.firstKeyType, equalTo(String::class))
-        assertThat(metadata.firstValueType, equalTo(String::class))
-        assertThat(metadata.joinKeyType, equalTo(String::class))
-        assertThat(metadata.joinValueType, equalTo(String::class))
+        metadata.proxyInterface.assert().isEqualTo(NotJoinAnnotation::class)
+        metadata.name.assert().isEqualTo("")
+        metadata.cacheName.assert().isEqualTo("NotJoinAnnotation")
+        metadata.firstCacheName.assert().isEqualTo("")
+        metadata.joinCacheName.assert().isEqualTo("")
+        metadata.joinKeyExpression.assert().isEqualTo("")
+        metadata.firstKeyType.classifier.assert().isEqualTo(String::class)
+        metadata.firstValueType.classifier.assert().isEqualTo(String::class)
+        metadata.joinKeyType.classifier.assert().isEqualTo(String::class)
+        metadata.joinValueType.classifier.assert().isEqualTo(String::class)
     }
 
     @Test

--- a/cocache-example/src/main/kotlin/me/ahoo/cache/example/config/ClassDefinedCacheConfiguration.kt
+++ b/cocache-example/src/main/kotlin/me/ahoo/cache/example/config/ClassDefinedCacheConfiguration.kt
@@ -41,7 +41,7 @@ class ClassDefinedCacheConfiguration {
         clientIdGenerator: ClientIdGenerator
     ): CoherentCache<String, User> {
         val clientId = clientIdGenerator.generate()
-        val codecExecutor = ObjectToJsonCodecExecutor(
+        val codecExecutor = ObjectToJsonCodecExecutor<User>(
             User::class.java,
             redisTemplate,
             objectMapper,

--- a/cocache-spring-cache/src/test/kotlin/me/ahoo/cache/spring/cache/CoCacheManagerTest.kt
+++ b/cocache-spring-cache/src/test/kotlin/me/ahoo/cache/spring/cache/CoCacheManagerTest.kt
@@ -20,6 +20,7 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers
 import org.junit.jupiter.api.Test
+import kotlin.reflect.KType
 
 class CoCacheManagerTest {
     object MockCacheFactory : CacheFactory {
@@ -35,8 +36,8 @@ class CoCacheManagerTest {
         }
 
         override fun <CACHE : Cache<*, *>> getCache(
-            keyType: Class<*>,
-            valueType: Class<*>
+            keyType: KType,
+            valueType: KType
         ): CACHE? {
             return null
         }

--- a/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/ObjectToJsonCodecExecutor.kt
+++ b/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/ObjectToJsonCodecExecutor.kt
@@ -17,6 +17,7 @@ import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.MissingGuard
 import me.ahoo.cache.api.CacheValue
 import org.springframework.data.redis.core.StringRedisTemplate
+import java.lang.reflect.Type
 
 /**
  * ObjectToJsonCodecExecutor .
@@ -24,11 +25,11 @@ import org.springframework.data.redis.core.StringRedisTemplate
  * @author ahoo wang
  */
 class ObjectToJsonCodecExecutor<V>(
-    private val valueType: Class<V>,
+    private val valueType: Type,
     private val redisTemplate: StringRedisTemplate,
     private val objectMapper: ObjectMapper
 ) : AbstractCodecExecutor<V, String>() {
-
+    private val valueJavaType = objectMapper.typeFactory.constructType(valueType)
     override fun CacheValue<V>.toRawValue(): String {
         if (isMissingGuard) {
             return MissingGuard.STRING_VALUE
@@ -45,7 +46,7 @@ class ObjectToJsonCodecExecutor<V>(
     }
 
     override fun decode(rawValue: String): V {
-        return objectMapper.readValue(rawValue, valueType)
+        return objectMapper.readValue(rawValue, valueJavaType)
     }
 
     override fun setForeverValue(key: String, cacheValue: CacheValue<V>) {

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/SpringCacheFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/SpringCacheFactory.kt
@@ -18,6 +18,8 @@ import me.ahoo.cache.api.Cache
 import org.springframework.beans.factory.ListableBeanFactory
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.core.ResolvableType
+import kotlin.reflect.KType
+import kotlin.reflect.javaType
 
 class SpringCacheFactory(private val beanFactory: ListableBeanFactory) : CacheFactory {
     override val caches: Map<String, Cache<*, *>>
@@ -34,11 +36,12 @@ class SpringCacheFactory(private val beanFactory: ListableBeanFactory) : CacheFa
         }
     }
 
-    override fun <CACHE : Cache<*, *>> getCache(keyType: Class<*>, valueType: Class<*>): CACHE? {
+    @OptIn(ExperimentalStdlibApi::class)
+    override fun <CACHE : Cache<*, *>> getCache(keyType: KType, valueType: KType): CACHE? {
         val cacheType = ResolvableType.forClassWithGenerics(
             Cache::class.java,
-            keyType,
-            valueType
+            ResolvableType.forType(keyType.javaType),
+            ResolvableType.forType(valueType.javaType)
         )
         val provider = beanFactory.getBeanProvider<CACHE>(cacheType)
         return provider.getIfAvailable {

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/client/SpringClientSideCacheFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/client/SpringClientSideCacheFactory.kt
@@ -20,7 +20,7 @@ import me.ahoo.cache.client.DefaultClientSideCacheFactory
 import me.ahoo.cache.spring.AbstractCacheFactory
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.core.ResolvableType
-import kotlin.reflect.javaType
+import kotlin.reflect.jvm.javaType
 
 class SpringClientSideCacheFactory(beanFactory: BeanFactory) : ClientSideCacheFactory,
     AbstractCacheFactory(beanFactory) {
@@ -30,7 +30,6 @@ class SpringClientSideCacheFactory(beanFactory: BeanFactory) : ClientSideCacheFa
 
     override val suffix: String = CLIENT_SIDE_CACHE_SUFFIX
 
-    @OptIn(ExperimentalStdlibApi::class)
     override fun getBeanType(cacheMetadata: CoCacheMetadata): ResolvableType {
         return ResolvableType.forClassWithGenerics(
             ClientSideCache::class.java,

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/client/SpringClientSideCacheFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/client/SpringClientSideCacheFactory.kt
@@ -20,6 +20,7 @@ import me.ahoo.cache.client.DefaultClientSideCacheFactory
 import me.ahoo.cache.spring.AbstractCacheFactory
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.core.ResolvableType
+import kotlin.reflect.javaType
 
 class SpringClientSideCacheFactory(beanFactory: BeanFactory) : ClientSideCacheFactory,
     AbstractCacheFactory(beanFactory) {
@@ -29,10 +30,11 @@ class SpringClientSideCacheFactory(beanFactory: BeanFactory) : ClientSideCacheFa
 
     override val suffix: String = CLIENT_SIDE_CACHE_SUFFIX
 
+    @OptIn(ExperimentalStdlibApi::class)
     override fun getBeanType(cacheMetadata: CoCacheMetadata): ResolvableType {
         return ResolvableType.forClassWithGenerics(
             ClientSideCache::class.java,
-            cacheMetadata.valueType.java
+            ResolvableType.forType(cacheMetadata.valueType.javaType)
         )
     }
 

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/converter/SpringKeyConverterFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/converter/SpringKeyConverterFactory.kt
@@ -22,7 +22,7 @@ import me.ahoo.cache.converter.ToStringKeyConverter
 import me.ahoo.cache.spring.AbstractCacheFactory
 import org.springframework.context.ApplicationContext
 import org.springframework.core.ResolvableType
-import kotlin.reflect.javaType
+import kotlin.reflect.jvm.javaType
 
 class SpringKeyConverterFactory(private val appContext: ApplicationContext) : KeyConverterFactory,
     AbstractCacheFactory(appContext) {
@@ -33,7 +33,6 @@ class SpringKeyConverterFactory(private val appContext: ApplicationContext) : Ke
 
     override val suffix: String = KEY_CONVERTER_SUFFIX
 
-    @OptIn(ExperimentalStdlibApi::class)
     override fun getBeanType(cacheMetadata: CoCacheMetadata): ResolvableType {
         return ResolvableType.forClassWithGenerics(
             KeyConverter::class.java,

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/converter/SpringKeyConverterFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/converter/SpringKeyConverterFactory.kt
@@ -22,6 +22,7 @@ import me.ahoo.cache.converter.ToStringKeyConverter
 import me.ahoo.cache.spring.AbstractCacheFactory
 import org.springframework.context.ApplicationContext
 import org.springframework.core.ResolvableType
+import kotlin.reflect.javaType
 
 class SpringKeyConverterFactory(private val appContext: ApplicationContext) : KeyConverterFactory,
     AbstractCacheFactory(appContext) {
@@ -32,15 +33,16 @@ class SpringKeyConverterFactory(private val appContext: ApplicationContext) : Ke
 
     override val suffix: String = KEY_CONVERTER_SUFFIX
 
+    @OptIn(ExperimentalStdlibApi::class)
     override fun getBeanType(cacheMetadata: CoCacheMetadata): ResolvableType {
         return ResolvableType.forClassWithGenerics(
             KeyConverter::class.java,
-            cacheMetadata.keyType.java
+            ResolvableType.forType(cacheMetadata.keyType.javaType)
         )
     }
 
     override fun getBeanProvider(cacheMetadata: CoCacheMetadata, fallback: () -> Any): Any {
-        if (cacheMetadata.keyType.java == String::class.java) {
+        if (cacheMetadata.keyType.classifier == String::class.java) {
             return fallback()
         }
         return super.getBeanProvider(cacheMetadata, fallback)

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/join/SpringJoinKeyExtractorFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/join/SpringJoinKeyExtractorFactory.kt
@@ -19,12 +19,14 @@ import me.ahoo.cache.join.ExpJoinKeyExtractor
 import me.ahoo.cache.join.JoinKeyExtractorFactory
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.core.ResolvableType
+import kotlin.reflect.javaType
 
 class SpringJoinKeyExtractorFactory(private val beanFactory: BeanFactory) : JoinKeyExtractorFactory {
     companion object {
         const val JOIN_KEY_EXTRACTOR_SUFFIX = ".JoinKeyExtractor"
     }
 
+    @OptIn(ExperimentalStdlibApi::class)
     override fun <V1, K2> create(cacheMetadata: JoinCacheMetadata): JoinKeyExtractor<V1, K2> {
         if (cacheMetadata.joinKeyExpression.isNotBlank()) {
             @Suppress("UNCHECKED_CAST")
@@ -35,10 +37,11 @@ class SpringJoinKeyExtractorFactory(private val beanFactory: BeanFactory) : Join
             @Suppress("UNCHECKED_CAST")
             return beanFactory.getBean(beanName) as JoinKeyExtractor<V1, K2>
         }
+
         val beanType = ResolvableType.forClassWithGenerics(
             JoinKeyExtractor::class.java,
-            cacheMetadata.firstValueType.java,
-            cacheMetadata.joinKeyType.java
+            ResolvableType.forType(cacheMetadata.firstValueType.javaType),
+            ResolvableType.forType(cacheMetadata.joinKeyType.javaType)
         )
 
         val provider = beanFactory.getBeanProvider<JoinKeyExtractor<V1, K2>>(beanType)

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/join/SpringJoinKeyExtractorFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/join/SpringJoinKeyExtractorFactory.kt
@@ -19,14 +19,13 @@ import me.ahoo.cache.join.ExpJoinKeyExtractor
 import me.ahoo.cache.join.JoinKeyExtractorFactory
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.core.ResolvableType
-import kotlin.reflect.javaType
+import kotlin.reflect.jvm.javaType
 
 class SpringJoinKeyExtractorFactory(private val beanFactory: BeanFactory) : JoinKeyExtractorFactory {
     companion object {
         const val JOIN_KEY_EXTRACTOR_SUFFIX = ".JoinKeyExtractor"
     }
 
-    @OptIn(ExperimentalStdlibApi::class)
     override fun <V1, K2> create(cacheMetadata: JoinCacheMetadata): JoinKeyExtractor<V1, K2> {
         if (cacheMetadata.joinKeyExpression.isNotBlank()) {
             @Suppress("UNCHECKED_CAST")

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/source/SpringCacheSourceFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/source/SpringCacheSourceFactory.kt
@@ -19,6 +19,7 @@ import me.ahoo.cache.source.CacheSourceFactory
 import me.ahoo.cache.spring.AbstractCacheFactory
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.core.ResolvableType
+import kotlin.reflect.javaType
 
 class SpringCacheSourceFactory(beanFactory: BeanFactory) : CacheSourceFactory,
     AbstractCacheFactory(beanFactory) {
@@ -27,11 +28,13 @@ class SpringCacheSourceFactory(beanFactory: BeanFactory) : CacheSourceFactory,
     }
 
     override val suffix: String = CACHE_SOURCE_SUFFIX
+
+    @OptIn(ExperimentalStdlibApi::class)
     override fun getBeanType(cacheMetadata: CoCacheMetadata): ResolvableType {
         return ResolvableType.forClassWithGenerics(
             CacheSource::class.java,
-            cacheMetadata.keyType.java,
-            cacheMetadata.valueType.java
+            ResolvableType.forType(cacheMetadata.keyType.javaType),
+            ResolvableType.forType(cacheMetadata.valueType.javaType)
         )
     }
 

--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/source/SpringCacheSourceFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/source/SpringCacheSourceFactory.kt
@@ -19,7 +19,7 @@ import me.ahoo.cache.source.CacheSourceFactory
 import me.ahoo.cache.spring.AbstractCacheFactory
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.core.ResolvableType
-import kotlin.reflect.javaType
+import kotlin.reflect.jvm.javaType
 
 class SpringCacheSourceFactory(beanFactory: BeanFactory) : CacheSourceFactory,
     AbstractCacheFactory(beanFactory) {
@@ -29,7 +29,6 @@ class SpringCacheSourceFactory(beanFactory: BeanFactory) : CacheSourceFactory,
 
     override val suffix: String = CACHE_SOURCE_SUFFIX
 
-    @OptIn(ExperimentalStdlibApi::class)
     override fun getBeanType(cacheMetadata: CoCacheMetadata): ResolvableType {
         return ResolvableType.forClassWithGenerics(
             CacheSource::class.java,


### PR DESCRIPTION
- Update CacheFactory interface to use KType instead of Class for key and value types
- Modify CoCacheMetadata and JoinCacheMetadata to use KType for type information
- Update related parsers and tests to work with KType
- Adjust Spring-specific classes to handle KType instead of Class
