### PR TITLE
refactor(cocache-spring): update key type classifier comparison

### DIFF
--- a/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/converter/SpringKeyConverterFactory.kt
+++ b/cocache-spring/src/main/kotlin/me/ahoo/cache/spring/converter/SpringKeyConverterFactory.kt
@@ -41,7 +41,7 @@ class SpringKeyConverterFactory(private val appContext: ApplicationContext) : Ke
     }
 
     override fun getBeanProvider(cacheMetadata: CoCacheMetadata, fallback: () -> Any): Any {
-        if (cacheMetadata.keyType.classifier == String::class.java) {
+        if (cacheMetadata.keyType.classifier == String::class) {
             return fallback()
         }
         return super.getBeanProvider(cacheMetadata, fallback)


### PR DESCRIPTION
- Change from using java class to kotlin class reference
- Improve type safety and consistency in key type checking

