### PR TITLE
feat(missingGuard): extract MissingGuard interface and implement DefaultMissingGuard

### DIFF
--- a/cocache-core/src/main/kotlin/me/ahoo/cache/MissingGuard.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/MissingGuard.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cache
+
+interface MissingGuard {
+    companion object {
+        const val STRING_VALUE = "_nil_"
+        val Any?.isMissingGuard: Boolean
+            get() {
+                return when (this) {
+                    is String -> {
+                        this.isMissingGuard()
+                    }
+
+                    is Set<*> -> {
+                        this.isMissingGuard()
+                    }
+
+                    is Map<*, *> -> {
+                        this.isMissingGuard()
+                    }
+
+                    else -> {
+                        this is MissingGuard
+                    }
+                }
+            }
+
+        fun String.isMissingGuard(): Boolean {
+            return this == STRING_VALUE
+        }
+
+        fun Set<*>.isMissingGuard(): Boolean {
+            return firstOrNull() == STRING_VALUE
+        }
+
+        fun Map<*, *>.isMissingGuard(): Boolean {
+            return keys.firstOrNull() == STRING_VALUE
+        }
+    }
+}

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/join/DefaultJoinValue.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/join/DefaultJoinValue.kt
@@ -1,6 +1,16 @@
 package me.ahoo.cache.join
 
+import me.ahoo.cache.MissingGuard
 import me.ahoo.cache.api.join.JoinValue
+
+object DefaultJoinMissingGuard : JoinValue<String, String, String>, MissingGuard {
+    override val firstValue: String
+        get() = MissingGuard.STRING_VALUE
+    override val joinKey: String
+        get() = MissingGuard.STRING_VALUE
+    override val secondValue: String?
+        get() = MissingGuard.STRING_VALUE
+}
 
 /**
  * Join Value.
@@ -11,4 +21,11 @@ data class DefaultJoinValue<V1, K2, V2>(
     override val firstValue: V1,
     override val joinKey: K2,
     override val secondValue: V2?
-) : JoinValue<V1, K2, V2>
+) : JoinValue<V1, K2, V2> {
+    companion object {
+        fun <V1, K2, V2> missingGuardValue(): JoinValue<V1, K2, V2> {
+            @Suppress("UNCHECKED_CAST")
+            return DefaultJoinMissingGuard as JoinValue<V1, K2, V2>
+        }
+    }
+}

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/join/DefaultJoinMissingGuardTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/join/DefaultJoinMissingGuardTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cache.join
+
+import me.ahoo.cache.MissingGuard
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+
+class DefaultJoinMissingGuardTest {
+    @Test
+    fun getFirstValue() {
+        DefaultJoinMissingGuard.firstValue.assert().isEqualTo(MissingGuard.STRING_VALUE)
+    }
+
+    @Test
+    fun getJoinKey() {
+        DefaultJoinMissingGuard.joinKey.assert().isEqualTo(MissingGuard.STRING_VALUE)
+    }
+
+    @Test
+    fun getSecondValue() {
+        DefaultJoinMissingGuard.secondValue.assert().isEqualTo(MissingGuard.STRING_VALUE)
+    }
+}

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/join/SimpleJoinCacheTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/join/SimpleJoinCacheTest.kt
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.Test
  */
 internal class SimpleJoinCacheTest : CacheSpec<String, JoinValue<Order, String, OrderAddress>>() {
 
+    override val missingGuard: JoinValue<Order, String, OrderAddress>
+        get() = DefaultJoinValue.missingGuardValue()
     override fun createCache(): Cache<String, JoinValue<Order, String, OrderAddress>> {
         val orderCache = MapClientSideCache<Order>()
         val orderAddressCache = MapClientSideCache<OrderAddress>()

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/join/proxy/DefaultJoinCacheProxyFactoryTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/join/proxy/DefaultJoinCacheProxyFactoryTest.kt
@@ -18,7 +18,8 @@ import me.ahoo.cache.test.CacheSpec
 import java.util.UUID
 
 class DefaultJoinCacheProxyFactoryTest : CacheSpec<String, JoinValue<OrderAddress, String, Order>>() {
-
+    override val missingGuard: JoinValue<OrderAddress, String, Order>
+        get() = DefaultJoinValue.missingGuardValue()
     override fun createCache(): JoinCache<String, OrderAddress, String, Order> {
         val cacheFactory = mockk<CacheFactory> {
             every { getCache<Cache<String, OrderAddress>>("OrderAddress") } returns MapClientSideCache()

--- a/cocache-spring-cache/src/test/kotlin/me/ahoo/cache/spring/cache/SpringCacheValueWrapperTest.kt
+++ b/cocache-spring-cache/src/test/kotlin/me/ahoo/cache/spring/cache/SpringCacheValueWrapperTest.kt
@@ -14,7 +14,7 @@
 package me.ahoo.cache.spring.cache
 
 import me.ahoo.cache.DefaultCacheValue
-import me.ahoo.cache.MissingGuard
+import me.ahoo.cache.DefaultMissingGuard
 import me.ahoo.cache.api.CacheValue
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.*
@@ -26,7 +26,7 @@ class SpringCacheValueWrapperTest {
 
     @Test
     fun get() {
-        assertThat(springCacheValueWrapper.get(), equalTo(MissingGuard))
+        assertThat(springCacheValueWrapper.get(), equalTo(DefaultMissingGuard))
     }
 
     @Test

--- a/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/MapToHashCodecExecutor.kt
+++ b/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/MapToHashCodecExecutor.kt
@@ -12,8 +12,8 @@
  */
 package me.ahoo.cache.spring.redis.codec
 
-import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.MissingGuard
+import me.ahoo.cache.MissingGuard.Companion.isMissingGuard
 import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.util.CacheSecondClock
 import org.springframework.data.redis.connection.StringRedisConnection
@@ -39,7 +39,7 @@ class MapToHashCodecExecutor(private val redisTemplate: StringRedisTemplate) :
     }
 
     override fun isMissingGuard(rawValue: Map<String, String>): Boolean {
-        return DefaultCacheValue.isMissingGuard(rawValue)
+        return rawValue.isMissingGuard
     }
 
     override fun decode(rawValue: Map<String, String>): Map<String, String> {

--- a/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/ObjectToHashCodecExecutor.kt
+++ b/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/ObjectToHashCodecExecutor.kt
@@ -12,8 +12,8 @@
  */
 package me.ahoo.cache.spring.redis.codec
 
-import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.MissingGuard
+import me.ahoo.cache.MissingGuard.Companion.isMissingGuard
 import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.util.CacheSecondClock
 import org.springframework.data.redis.connection.StringRedisConnection
@@ -64,7 +64,7 @@ class ObjectToHashCodecExecutor<V>(
     }
 
     override fun isMissingGuard(rawValue: Map<String, String>): Boolean {
-        return DefaultCacheValue.isMissingGuard(rawValue)
+        return rawValue.isMissingGuard
     }
 
     interface MapConverter<V> {

--- a/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/ObjectToJsonCodecExecutor.kt
+++ b/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/ObjectToJsonCodecExecutor.kt
@@ -13,8 +13,8 @@
 package me.ahoo.cache.spring.redis.codec
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.MissingGuard
+import me.ahoo.cache.MissingGuard.Companion.isMissingGuard
 import me.ahoo.cache.api.CacheValue
 import org.springframework.data.redis.core.StringRedisTemplate
 import java.lang.reflect.Type
@@ -38,7 +38,7 @@ class ObjectToJsonCodecExecutor<V>(
     }
 
     override fun isMissingGuard(rawValue: String): Boolean {
-        return DefaultCacheValue.isMissingGuard(rawValue)
+        return rawValue.isMissingGuard
     }
 
     override fun getRawValue(key: String): String? {

--- a/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/SetToSetCodecExecutor.kt
+++ b/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/SetToSetCodecExecutor.kt
@@ -12,8 +12,8 @@
  */
 package me.ahoo.cache.spring.redis.codec
 
-import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.MissingGuard
+import me.ahoo.cache.MissingGuard.Companion.isMissingGuard
 import me.ahoo.cache.api.CacheValue
 import org.springframework.data.redis.connection.StringRedisConnection
 import org.springframework.data.redis.core.StringRedisTemplate
@@ -36,7 +36,7 @@ class SetToSetCodecExecutor(private val redisTemplate: StringRedisTemplate) :
     }
 
     override fun isMissingGuard(rawValue: Set<String>): Boolean {
-        return DefaultCacheValue.isMissingGuard(rawValue)
+        return rawValue.isMissingGuard
     }
 
     override fun getRawValue(key: String): Set<String>? {

--- a/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/StringToStringCodecExecutor.kt
+++ b/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/codec/StringToStringCodecExecutor.kt
@@ -12,8 +12,8 @@
  */
 package me.ahoo.cache.spring.redis.codec
 
-import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.MissingGuard
+import me.ahoo.cache.MissingGuard.Companion.isMissingGuard
 import me.ahoo.cache.api.CacheValue
 import org.springframework.data.redis.core.StringRedisTemplate
 
@@ -33,7 +33,7 @@ class StringToStringCodecExecutor(private val redisTemplate: StringRedisTemplate
     }
 
     override fun isMissingGuard(rawValue: String): Boolean {
-        return DefaultCacheValue.isMissingGuard(rawValue)
+        return rawValue.isMissingGuard
     }
 
     override fun getRawValue(key: String): String? {

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/CacheSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/CacheSpec.kt
@@ -15,6 +15,7 @@ package me.ahoo.cache.test
 
 import me.ahoo.cache.ComputedTtlAt
 import me.ahoo.cache.DefaultCacheValue
+import me.ahoo.cache.MissingGuard
 import me.ahoo.cache.api.Cache
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -27,6 +28,7 @@ abstract class CacheSpec<K, V> {
     protected abstract fun createCache(): Cache<K, V>
     protected abstract fun createCacheEntry(): Pair<K, V>
     protected lateinit var cache: Cache<K, V>
+    protected open val missingGuard: V = DefaultCacheValue.missingGuardValue()
 
     @BeforeEach
     open fun setup() {
@@ -88,7 +90,7 @@ abstract class CacheSpec<K, V> {
     @Test
     fun setMissing() {
         val (key, value) = createCacheEntry()
-        cache[key] = DefaultCacheValue.missingGuardValue()
+        cache[key] = missingGuard
         Assertions.assertNull(cache[key])
         Assertions.assertNull(cache.getTtlAt(key))
     }
@@ -96,7 +98,7 @@ abstract class CacheSpec<K, V> {
     @Test
     fun setMissingTtl() {
         val (key, value) = createCacheEntry()
-        cache.setCache(key, DefaultCacheValue.missingGuard(5))
+        cache.setCache(key, DefaultCacheValue.missingGuard(missingGuard as MissingGuard, 5))
         Assertions.assertNull(cache[key])
         Assertions.assertNull(cache.getTtlAt(key))
     }

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/DefaultCoherentCacheSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/DefaultCoherentCacheSpec.kt
@@ -54,6 +54,7 @@ abstract class DefaultCoherentCacheSpec<K, V> : CacheSpec<K, V>() {
     private val cacheSource = object : CacheSource<K, V> {
         override fun loadCacheValue(key: K): CacheValue<V>? {
             Thread.sleep(100)
+            @Suppress("UNCHECKED_CAST")
             return CACHE_SOURCE_VALUE.get() as CacheValue<V>?
         }
     }


### PR DESCRIPTION
- Extract MissingGuard interface from DefaultCacheValue
- Implement DefaultMissingGuard as a concrete implementation of MissingGuard
- Update CacheSpec and other classes to use the new MissingGuard interface
- Modify isMissingGuard logic to use the new interface
- Adjust tests to work with the new MissingGuard implementation

