### PR TITLE
build(deps): replace hamcrest with fluent-assert and update dependencies

### DIFF
--- a/cocache-core/build.gradle.kts
+++ b/cocache-core/build.gradle.kts
@@ -2,10 +2,11 @@ dependencies {
     api(project(":cocache-api"))
     api("me.ahoo.cosid:cosid-core")
     api(kotlin("reflect"))
-    implementation("com.google.guava:guava")
+    compileOnly("com.google.guava:guava")
     compileOnly("com.github.ben-manes.caffeine:caffeine")
     api("io.github.oshai:kotlin-logging-jvm")
     implementation("org.springframework:spring-expression")
+    testImplementation("com.google.guava:guava")
     testImplementation("com.github.ben-manes.caffeine:caffeine")
     testImplementation(project(":cocache-test"))
 }

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/client/CaffeineCacheTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/client/CaffeineCacheTest.kt
@@ -12,8 +12,12 @@
  */
 package me.ahoo.cache.client
 
+import me.ahoo.cache.api.annotation.CaffeineCache
 import me.ahoo.cache.api.client.ClientSideCache
+import me.ahoo.cache.client.CaffeineClientSideCache.Companion.toClientSideCache
 import me.ahoo.cache.test.ClientSideCacheSpec
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
 import java.util.*
 
 /**
@@ -29,5 +33,11 @@ internal class CaffeineCacheTest : ClientSideCacheSpec<String>() {
 
     override fun createCacheEntry(): Pair<String, String> {
         return UUID.randomUUID().toString() to UUID.randomUUID().toString()
+    }
+
+    @Test
+    fun defaultCacheConvert() {
+        val cache = CaffeineCache().toClientSideCache<String>()
+        cache.assert().isNotNull()
     }
 }

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/client/GuavaCacheTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/client/GuavaCacheTest.kt
@@ -12,8 +12,12 @@
  */
 package me.ahoo.cache.client
 
+import me.ahoo.cache.api.annotation.GuavaCache
 import me.ahoo.cache.api.client.ClientSideCache
+import me.ahoo.cache.client.GuavaClientSideCache.Companion.toClientSideCache
 import me.ahoo.cache.test.ClientSideCacheSpec
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
 import java.util.*
 
 /**
@@ -29,5 +33,11 @@ internal class GuavaCacheTest : ClientSideCacheSpec<String>() {
 
     override fun createCacheEntry(): Pair<String, String> {
         return UUID.randomUUID().toString() to UUID.randomUUID().toString()
+    }
+
+    @Test
+    fun defaultCacheConvert() {
+        val cache = GuavaCache().toClientSideCache<String>()
+        cache.assert().isNotNull()
     }
 }

--- a/cocache-dependencies/build.gradle.kts
+++ b/cocache-dependencies/build.gradle.kts
@@ -19,7 +19,6 @@ dependencies {
         api(libs.guava)
         api(libs.kotlin.logging)
         api(libs.springdoc.openapi.starter.webflux.ui)
-        api(libs.hamcrest)
         api(libs.mockk)
         api(libs.detekt.formatting)
     }

--- a/cocache-test/build.gradle.kts
+++ b/cocache-test/build.gradle.kts
@@ -2,7 +2,7 @@ description = "The Technology Compatibility Kit"
 
 dependencies {
     api(project(":cocache-core"))
-    api("org.hamcrest:hamcrest")
+    api("me.ahoo.test:fluent-assert-core")
     implementation("org.junit.jupiter:junit-jupiter-api")
     implementation("org.junit.jupiter:junit-jupiter-params")
 }

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/CacheSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/CacheSpec.kt
@@ -17,10 +17,7 @@ import me.ahoo.cache.ComputedTtlAt
 import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.MissingGuard
 import me.ahoo.cache.api.Cache
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
-import org.hamcrest.Matchers.nullValue
-import org.junit.jupiter.api.Assertions
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -38,7 +35,7 @@ abstract class CacheSpec<K, V> {
     @Test
     fun get() {
         val (key, value) = createCacheEntry()
-        assertThat(cache[key], nullValue())
+        cache[key].assert().isNull()
     }
 
     @Test
@@ -46,60 +43,60 @@ abstract class CacheSpec<K, V> {
         val (key, value) = createCacheEntry()
         val ttlAt = ComputedTtlAt.at(-5)
         cache[key, ttlAt] = value
-        assertThat(cache[key], nullValue())
-        assertThat(cache.getTtlAt(key), nullValue())
+        cache[key].assert().isNull()
+        cache.getTtlAt(key).assert().isNull()
     }
 
     @Test
     fun set() {
         val (key, value) = createCacheEntry()
-        assertThat(cache[key], nullValue())
+        cache[key].assert().isNull()
         cache[key] = value
-        assertThat(cache[key], equalTo(value))
+        cache[key].assert().isEqualTo(value)
     }
 
     @Test
     fun setWithTtl() {
         val (key, value) = createCacheEntry()
-        assertThat(cache[key], nullValue())
+        cache[key].assert().isNull()
         val cacheValue = DefaultCacheValue.ttlAt(value, 5)
         cache.setCache(key, cacheValue)
-        assertThat(cache[key], equalTo(value))
-        assertThat(cache.getTtlAt(key), equalTo(cacheValue.ttlAt))
+        cache[key].assert().isEqualTo(value)
+        cache.getTtlAt(key).assert().isEqualTo(cacheValue.ttlAt)
     }
 
     @Test
     fun setWithTtlAmplitude() {
         val (key, value) = createCacheEntry()
-        assertThat(cache[key], nullValue())
+        cache[key].assert().isNull()
         val cacheValue = DefaultCacheValue.ttlAt(value, 5, 1)
         cache.setCache(key, cacheValue)
-        assertThat(cache[key], equalTo(value))
-        assertThat(cache.getTtlAt(key), equalTo(cacheValue.ttlAt))
+        cache[key].assert().isEqualTo(value)
+        cache.getTtlAt(key).assert().isEqualTo(cacheValue.ttlAt)
     }
 
     @Test
     fun evict() {
         val (key, value) = createCacheEntry()
         cache[key] = value
-        assertThat(cache[key], equalTo(value))
+        cache[key].assert().isEqualTo(value)
         cache.evict(key)
-        assertThat(cache[key], nullValue())
+        cache[key].assert().isNull()
     }
 
     @Test
     fun setMissing() {
         val (key, value) = createCacheEntry()
         cache[key] = missingGuard
-        Assertions.assertNull(cache[key])
-        Assertions.assertNull(cache.getTtlAt(key))
+        cache[key].assert().isNull()
+        cache.getTtlAt(key).assert().isNull()
     }
 
     @Test
     fun setMissingTtl() {
         val (key, value) = createCacheEntry()
         cache.setCache(key, DefaultCacheValue.missingGuard(missingGuard as MissingGuard, 5))
-        Assertions.assertNull(cache[key])
-        Assertions.assertNull(cache.getTtlAt(key))
+        cache[key].assert().isNull()
+        cache.getTtlAt(key).assert().isNull()
     }
 }

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/ClientSideCacheSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/ClientSideCacheSpec.kt
@@ -23,9 +23,11 @@ abstract class ClientSideCacheSpec<V> : CacheSpec<String, V>() {
 
     @Test
     fun clear() {
+        val clientSideCache = cache as ClientSideCache<V>
         val (key, value) = createCacheEntry()
-        cache[key] = value
-        (cache as ClientSideCache<V>).clear()
+        clientSideCache[key] = value
+        clientSideCache.clear()
         cache[key].assert().isNull()
+        clientSideCache.size.assert().isZero()
     }
 }

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/ClientSideCacheSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/ClientSideCacheSpec.kt
@@ -14,8 +14,7 @@
 package me.ahoo.cache.test
 
 import me.ahoo.cache.api.client.ClientSideCache
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.nullValue
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 abstract class ClientSideCacheSpec<V> : CacheSpec<String, V>() {
@@ -27,6 +26,6 @@ abstract class ClientSideCacheSpec<V> : CacheSpec<String, V>() {
         val (key, value) = createCacheEntry()
         cache[key] = value
         (cache as ClientSideCache<V>).clear()
-        assertThat(cache[key], nullValue())
+        cache[key].assert().isNull()
     }
 }

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/DefaultCoherentCacheSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/DefaultCoherentCacheSpec.kt
@@ -25,8 +25,7 @@ import me.ahoo.cache.consistency.CoherentCacheConfiguration
 import me.ahoo.cache.consistency.DefaultCoherentCacheFactory
 import me.ahoo.cache.converter.KeyConverter
 import me.ahoo.cache.distributed.DistributedCache
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -93,7 +92,7 @@ abstract class DefaultCoherentCacheSpec<K, V> : CacheSpec<K, V>() {
         val (key, value) = createCacheEntry()
         val cacheValue = DefaultCacheValue.forever(value)
         CACHE_SOURCE_VALUE.set(cacheValue)
-        assertThat(coherentCache[key], equalTo(value))
+        coherentCache[key].assert().isEqualTo(value)
         CACHE_SOURCE_VALUE.remove()
     }
 
@@ -105,9 +104,9 @@ abstract class DefaultCoherentCacheSpec<K, V> : CacheSpec<K, V>() {
         val cacheKey = keyConverter.toStringKey(key)
         val event = CacheEvictedEvent(cacheName, cacheKey, "")
         coherentCache.onEvicted(event)
-        assertThat(clientSideCache[cacheKey], nullValue())
-        assertThat(distributedCache[cacheKey], equalTo(value))
-        assertThat(coherentCache[key], equalTo(value))
+        clientSideCache[cacheKey].assert().isNull()
+        distributedCache[cacheKey].assert().isEqualTo(value)
+        coherentCache[key].assert().isEqualTo(value)
     }
 
     @Test
@@ -118,9 +117,9 @@ abstract class DefaultCoherentCacheSpec<K, V> : CacheSpec<K, V>() {
         val cacheKey = keyConverter.toStringKey(key)
         val event = CacheEvictedEvent(cacheName, cacheKey, clientId)
         coherentCache.onEvicted(event)
-        assertThat(clientSideCache[cacheKey], equalTo(value))
-        assertThat(distributedCache[cacheKey], equalTo(value))
-        assertThat(coherentCache[key], equalTo(value))
+        clientSideCache[cacheKey].assert().isEqualTo(value)
+        distributedCache[cacheKey].assert().isEqualTo(value)
+        coherentCache[key].assert().isEqualTo(value)
     }
 
     @Test
@@ -131,9 +130,9 @@ abstract class DefaultCoherentCacheSpec<K, V> : CacheSpec<K, V>() {
         val cacheKey = keyConverter.toStringKey(key)
         val event = CacheEvictedEvent(UUID.randomUUID().toString(), cacheKey, "")
         coherentCache.onEvicted(event)
-        assertThat(clientSideCache[cacheKey], equalTo(value))
-        assertThat(distributedCache[cacheKey], equalTo(value))
-        assertThat(coherentCache[key], equalTo(value))
+        clientSideCache[cacheKey].assert().isEqualTo(value)
+        distributedCache[cacheKey].assert().isEqualTo(value)
+        coherentCache[key].assert().isEqualTo(value)
     }
 
     @ParameterizedTest
@@ -175,8 +174,7 @@ abstract class DefaultCoherentCacheSpec<K, V> : CacheSpec<K, V>() {
 
         startLatch.countDown()
         finishLatch.await(5, TimeUnit.SECONDS)
-
-        assertThat("所有线程应获得相同结果", results.all { it == value })
-        assertThat("缓存源应只加载一次", callCount.get(), equalTo(1)) // 核心断言
+        results.all { it == value }.assert().isTrue()
+        callCount.get().assert().isOne() // 核心断言
     }
 }

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/consistency/CacheEvictedEventBusSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/consistency/CacheEvictedEventBusSpec.kt
@@ -16,8 +16,7 @@ package me.ahoo.cache.test.consistency
 import me.ahoo.cache.consistency.CacheEvictedEvent
 import me.ahoo.cache.consistency.CacheEvictedEventBus
 import me.ahoo.cache.consistency.CacheEvictedSubscriber
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import java.util.UUID
 import java.util.concurrent.CountDownLatch
@@ -35,7 +34,7 @@ abstract class CacheEvictedEventBusSpec {
         val evictedEvent = CacheEvictedEvent(cacheName, "publish", UUID.randomUUID().toString())
         val subscriber = object : CacheEvictedSubscriber {
             override fun onEvicted(cacheEvictedEvent: CacheEvictedEvent) {
-                assertThat(evictedEvent, equalTo(cacheEvictedEvent))
+                evictedEvent.assert().isEqualTo(cacheEvictedEvent)
                 countDownLatch.countDown()
             }
 
@@ -45,7 +44,7 @@ abstract class CacheEvictedEventBusSpec {
 
         eventBus.register(subscriber)
         eventBus.publish(evictedEvent)
-        assertThat(countDownLatch.await(1, TimeUnit.SECONDS), equalTo(true))
+        countDownLatch.await(1, TimeUnit.SECONDS).assert().isTrue()
     }
 
     @Test
@@ -57,7 +56,7 @@ abstract class CacheEvictedEventBusSpec {
         val evictedEvent = CacheEvictedEvent(cacheName, "unregister", UUID.randomUUID().toString())
         val subscriber = object : CacheEvictedSubscriber {
             override fun onEvicted(cacheEvictedEvent: CacheEvictedEvent) {
-                assertThat(evictedEvent, equalTo(cacheEvictedEvent))
+                evictedEvent.assert().isEqualTo(cacheEvictedEvent)
                 countDownLatch.countDown()
                 countDownLatch2.countDown()
             }
@@ -67,9 +66,9 @@ abstract class CacheEvictedEventBusSpec {
         }
         eventBus.register(subscriber)
         eventBus.publish(evictedEvent)
-        assertThat(countDownLatch.await(1, TimeUnit.SECONDS), equalTo(true))
+        countDownLatch.await(1, TimeUnit.SECONDS).assert().isTrue()
         eventBus.unregister(subscriber)
         eventBus.publish(evictedEvent)
-        assertThat(countDownLatch2.await(2, TimeUnit.SECONDS), equalTo(false))
+        countDownLatch2.await(2, TimeUnit.SECONDS).assert().isFalse()
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,6 @@ springdoc = "2.8.9"
 # testing
 junit = "5.13.2"
 fluent-assert = "0.2.0"
-hamcrest = "3.0"
 mockk = "1.14.4"
 # plugins
 detekt = "1.23.8"
@@ -24,7 +23,6 @@ kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = 
 springdoc-openapi-starter-webflux-ui = { module = "org.springdoc:springdoc-openapi-starter-webflux-ui", version.ref = "springdoc" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 fluent-assert-bom = { module = "me.ahoo.test:fluent-assert-bom", version.ref = "fluent-assert" }
-hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 [plugins]


### PR DESCRIPTION
- Remove hamcrest dependency from cocache-core, cocache-dependencies, and gradle/libs.versions.toml
- Add fluent-assert dependency to cocache-test and gradle/libs.versions.toml
- Update build.gradle.kts files to use compileOnly and testImplementation instead of api for some dependencies
- Refactor test code to use fluent-assert instead of hamcrest for assertions