### PR TITLE
build: add explicit nexus URL for Maven publish

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -208,6 +208,7 @@ configure(publishProjects) {
 nexusPublishing {
     this.repositories {
         sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
             username.set(System.getenv("MAVEN_USERNAME"))
             password.set(System.getenv("MAVEN_PASSWORD"))
         }


### PR DESCRIPTION
- Add explicit nexusUrl to the sonatype repository configuration
- This change ensures clarity and consistency in the build configuration

