### PR TITLE
docs(skills): optimize cocache skills metadata

### DIFF
--- a/skills/cocache/SKILL.md
+++ b/skills/cocache/SKILL.md
@@ -1,156 +1,67 @@
 ---
 name: cocache
-description: Use when building Spring Boot applications with CoCache distributed caching. Invoke whenever the user mentions CoCache, coherent cache, two-level cache, L2 cache, distributed cache coherence, @CoCache, @JoinCacheable, cache proxy, or wants to set up caching with Redis + local cache in a Java/Kotlin project. Also triggers on cache stampede prevention, cache breakdown protection, or event-driven cache invalidation.
+description: Use when building or modifying Java/Kotlin applications with CoCache two-level distributed coherent caching. Invoke for @CoCache cache interfaces, @JoinCacheable composition, Redis-backed coherence, Spring Boot integration, cache proxy behavior, custom cache backends, cache breakdown protection, or CoCache TCK tests.
 ---
 
 # CoCache Development Guide
 
-CoCache is a Level 2 Distributed Coherence Cache Framework for Java/Kotlin. It provides a two-level caching architecture:
-- **L2 (Client-side)**: Local in-memory cache (Map/Guava/Caffeine)
-- **L1 (Distributed)**: Shared cache layer (Redis)
+CoCache is a Java/Kotlin two-level distributed coherent cache framework:
+- L2 client-side cache: local Map, Guava, or Caffeine cache.
+- L1 distributed cache: Redis-backed shared cache.
+- Coherence: `CacheEvictedEventBus` publishes evictions so peer instances invalidate local entries.
 
-Cache coherence is maintained via an event bus that publishes `CacheEvictedEvent` when entries change, invalidating local caches across all instances.
+## Start Here
 
-## Quick Start
+Choose the smallest reference that fits the request:
 
-To add CoCache to a Spring Boot project, read `references/setup.md`.
+| Task | Read |
+|------|------|
+| Add CoCache to a Spring or Spring Boot app | `references/setup.md` |
+| Compose cached values with `@JoinCacheable` | `references/join-cache.md` |
+| Write or update tests | `references/testing.md` |
+| Implement a custom L1/L2 cache, event bus, key converter, or source | `references/custom-implementation.md` |
 
-## Core Concept: Cache Interfaces
+## Repository Rules
 
-CoCache uses a proxy-based approach. You define a **cache interface** extending `Cache<K, V>`, annotate it, and CoCache generates the implementation at runtime. This is the primary way to use the library.
+When editing this repository, follow `AGENTS.md`:
+- Use `me.ahoo.test.asserts.assert` and `.assert()` in Kotlin tests; do not use AssertJ `assertThat()`.
+- Extend the TCK specs in `cocache-test` for cache implementations.
+- Ask before changing `cocache-api` public interfaces or adding dependencies.
+- Run the relevant Gradle checks before finishing; prefer `./gradlew check` for broad changes.
 
-### Creating a Cache Interface
+## Core Model
+
+Define one cache interface per cache domain. The interface extends `Cache<K, V>`, is annotated with `@CoCache`, and is registered through `@EnableCoCache`. CoCache creates a proxy at runtime.
 
 ```kotlin
 @CoCache(keyPrefix = "user:", ttl = 120)
 @GuavaCache(maximumSize = 1_000_000, expireAfterAccess = 120, expireUnit = TimeUnit.SECONDS)
 interface UserCache : Cache<String, User>
-```
 
-Then register it:
-
-```kotlin
 @SpringBootApplication
 @EnableCoCache(caches = [UserCache::class])
 class App
 ```
 
-The proxy object injected into your code is **both** the `UserCache` interface and a `CoherentCache`, so you can cast to `CoherentCache` if you need access to internals like `clientSideCache.size`.
+Use caches through Kotlin operators: `cache[key]`, `cache[key] = value`, `cache.evict(key)`, and `cache.getCache(key)` when `CacheValue` metadata is required.
 
-### Using a Cache
+## Extension Points
 
-```kotlin
-@Service
-class UserService(@Qualifier("userCache") private val userCache: UserCache) {
+CoCache auto-configures defaults, but each component can be overridden:
+- Per cache, define named beans such as `UserCache.CacheSource`, `UserCache.ClientSideCache`, `UserCache.KeyConverter`, or `UserCache.JoinKeyExtractor`.
+- Globally, define beans by type; auto-configured beans use `@ConditionalOnMissingBean`.
+- For data loading, implement `CacheSource<K, V>.loadCacheValue(key)` and return `DefaultCacheValue.forever(value)`, `DefaultCacheValue.ttlAt(value, ttl)`, or `DefaultCacheValue.missingGuard()`.
 
-    fun getUser(id: String): User? {
-        return userCache[id]              // CacheGetter operator
-    }
+## Testing Pattern
 
-    fun saveUser(user: User) {
-        userCache[user.id] = user         // CacheSetter operator
-    }
+CoCache provides abstract specs in `cocache-test` for compatibility coverage:
+- `CacheSpec<K,V>` for base cache behavior.
+- `ClientSideCacheSpec<V>` for L2 caches.
+- `DistributedCacheSpec<V>` for L1 caches.
+- `DefaultCoherentCacheSpec<K,V>` for two-level coherent cache behavior and cache breakdown protection.
+- `MultipleInstanceSyncSpec<K,V>` and `CacheEvictedEventBusSpec` for cross-instance coherence and event buses.
 
-    fun deleteUser(id: String) {
-        userCache.evict(id)
-    }
-}
-```
-
-### @CoCache Annotation Reference
-
-| Property | Default | Description |
-|----------|---------|-------------|
-| `name` | interface simpleName | Cache bean name |
-| `keyPrefix` | `""` | Prefix prepended to all cache keys |
-| `keyExpression` | `""` | SpEL expression for key derivation |
-| `ttl` | `Long.MAX_VALUE` | TTL in seconds (forever by default) |
-| `ttlAmplitude` | `10` | Random TTL variance to prevent thundering herd |
-
-### @GuavaCache / @CaffeineCache Annotation Reference
-
-| Property | Default | Description |
-|----------|---------|-------------|
-| `initialCapacity` | `-1` (unset) | Initial capacity |
-| `maximumSize` | `-1` (unset) | Maximum entries |
-| `expireUnit` | `SECONDS` | Time unit for expiry values |
-| `expireAfterWrite` | `-1` (unset) | Expire after write duration |
-| `expireAfterAccess` | `-1` (unset) | Expire after access duration |
-| `concurrencyLevel` | `-1` (Guava only) | Concurrency level |
-
-## Customizing Cache Behavior
-
-CoCache auto-configures defaults, but every component can be overridden via Spring beans.
-
-### Per-Cache Bean Naming Convention
-
-For a cache named `UserCache`, define beans with these names:
-
-```kotlin
-@Bean("UserCache.CacheSource")
-fun userCacheSource(): CacheSource<String, User> {
-    return CacheSource { key ->
-        val user = userRepository.findById(key).orElse(null)
-        user?.let { DefaultCacheValue(it) }
-    }
-}
-
-@Bean("UserCache.ClientSideCache")
-fun userClientSideCache(): ClientSideCache<User> {
-    return CaffeineClientSideCache(
-        maximumSize = 500_000,
-        expireAfterAccess = Duration.ofSeconds(60)
-    )
-}
-```
-
-Available suffixes: `.ClientSideCache`, `.CacheSource`, `.KeyConverter`, `.JoinKeyExtractor`
-
-### Global Bean Override
-
-Define beans by type to override defaults for all caches:
-
-```kotlin
-@Bean
-fun cacheEvictedEventBus(): CacheEvictedEventBus {
-    return GuavaCacheEvictedEventBus()  // single-instance, no Redis needed
-}
-```
-
-All auto-configured beans use `@ConditionalOnMissingBean`, so any bean you define takes precedence.
-
-## JoinCache: Composing Cached Values
-
-JoinCache composes two independent caches into one logical view. Read `references/join-cache.md` for the full guide.
-
-**Quick example:**
-
-```kotlin
-@CoCache(keyPrefix = "user:", ttl = 120)
-interface UserCache : Cache<String, User>
-
-@CoCache(keyPrefix = "user_ext:", ttl = 120)
-interface UserExtendInfoCache : Cache<String, UserExtendInfo>
-
-@JoinCacheable(
-    firstCacheName = "UserExtendInfoCache",
-    joinCacheName = "UserCache",
-    joinKeyExpression = "#{#root.userId}"
-)
-interface UserExtendInfoJoinCache : JoinCache<String, UserExtendInfo, String, User>
-```
-
-When you call `userExtendInfoJoinCache.get("extInfo123")`:
-1. Gets `UserExtendInfo` from `UserExtendInfoCache`
-2. Evaluates `#{#root.userId}` to extract the userId
-3. Gets `User` from `UserCache` by that userId
-4. Returns `JoinValue<UserExtendInfo, String, User>`
-
-## Writing Tests
-
-CoCache provides abstract test specs in `cocache-test` that verify cache contracts. Read `references/testing.md` for the full guide.
-
-**Key pattern:** Extend the appropriate spec and implement factory methods:
+Use the repo's `createCacheEntry(): Pair<K, V>` contract:
 
 ```kotlin
 class MyDistributedCacheTest : DistributedCacheSpec<String>() {
@@ -158,60 +69,13 @@ class MyDistributedCacheTest : DistributedCacheSpec<String>() {
         return MyDistributedCache()
     }
 
-    override fun createCacheEntry(): CacheValue<String> {
-        return DefaultCacheValue("test_value")
+    override fun createCacheEntry(): Pair<String, String> {
+        return UUID.randomUUID().toString() to "test_value"
     }
 }
 ```
 
-## Creating Custom Implementations
-
-To implement a custom `ClientSideCache`, `DistributedCache`, or `CacheEvictedEventBus`, read `references/custom-implementation.md`.
-
-## Spring Cache Bridge
-
-CoCache integrates with Spring's `@Cacheable` abstraction via `cocache-spring-cache`. When `@EnableCaching` is present, a `CoCacheManager` is auto-configured, allowing:
-
-```kotlin
-@Cacheable(cacheNames = ["userCache"])
-fun getUser(id: String): User? { ... }
-```
-
-This routes through CoCache's two-level cache automatically.
-
-## Actuator Endpoints
-
-When Spring Actuator is on the classpath:
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/actuator/cocache` | GET | List all coherent caches |
-| `/actuator/cocache/{name}` | GET | Cache stats |
-| `/actuator/cocache/{name}/{key}` | GET | Get a cache entry |
-| `/actuator/cocache/{name}/{key}` | DELETE | Evict a cache entry |
-| `/actuator/cocacheClient` | GET | Client-side cache info |
-
-## Build Commands
-
-```bash
-# Build without tests
-./gradlew build -x test
-
-# Run all tests
-./gradlew test
-
-# Run tests for a specific module
-./gradlew :cocache-core:test
-
-# Run a single test class
-./gradlew :cocache-core:test --tests "me.ahoo.cache.proxy.ProxyCacheTest"
-
-# Run integration tests (requires Redis)
-./gradlew :cocache-spring-redis:check
-./gradlew :cocache-spring-boot-starter:check
-```
-
-## Key Classes Reference
+## Key Classes
 
 | Class | Module | Purpose |
 |-------|--------|---------|
@@ -231,3 +95,15 @@ When Spring Actuator is on the classpath:
 | `SimpleJoinCache` | cocache-core | Default JoinCache impl |
 | `KeyFilter` | cocache-core | Bloom filter for cache breakdown protection |
 | `BloomKeyFilter` | cocache-core | Guava BloomFilter impl |
+
+## Build Commands
+
+```bash
+./gradlew build -x test
+./gradlew test
+./gradlew :cocache-core:test
+./gradlew :cocache-core:test --tests "me.ahoo.cache.proxy.ProxyCacheTest"
+./gradlew :cocache-spring-redis:check
+./gradlew :cocache-spring-boot-starter:check
+./gradlew check
+```

--- a/skills/cocache/SKILL.md
+++ b/skills/cocache/SKILL.md
@@ -50,7 +50,7 @@ Use caches through Kotlin operators: `cache[key]`, `cache[key] = value`, `cache.
 CoCache auto-configures defaults, but each component can be overridden:
 - Per cache, define named beans such as `UserCache.CacheSource`, `UserCache.ClientSideCache`, `UserCache.KeyConverter`, or `UserCache.JoinKeyExtractor`.
 - Globally, define beans by type; auto-configured beans use `@ConditionalOnMissingBean`.
-- For data loading, implement `CacheSource<K, V>.loadCacheValue(key)` and return `DefaultCacheValue.forever(value)`, `DefaultCacheValue.ttlAt(value, ttl)`, or `DefaultCacheValue.missingGuard()`.
+- For data loading, implement `CacheSource<K, V>.loadCacheValue(key)` and return `DefaultCacheValue.forever(value)`, `DefaultCacheValue.ttlAt(value, ttl)`, or bounded `DefaultCacheValue.missingGuard(ttl, amplitude)` values.
 
 ## Testing Pattern
 

--- a/skills/cocache/agents/openai.yaml
+++ b/skills/cocache/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CoCache"
+  short_description: "Build two-level coherent caches"
+  default_prompt: "Use $cocache to design, implement, or test CoCache two-level distributed coherent caching."

--- a/skills/cocache/references/custom-implementation.md
+++ b/skills/cocache/references/custom-implementation.md
@@ -148,7 +148,15 @@ class MemcachedDistributedCache<V>(
         if (cacheValue.isExpired) {
             return
         }
-        val ttlSeconds = if (cacheValue.isForever) 0 else cacheValue.expiredDuration.seconds.toInt()
+        if (cacheValue.isForever) {
+            client.set("$keyPrefix$key", 0, codec.encode(cacheValue))
+            return
+        }
+
+        val ttlSeconds = cacheValue.expiredDuration.seconds.toInt()
+        if (ttlSeconds <= 0) {
+            return
+        }
         client.set("$keyPrefix$key", ttlSeconds, codec.encode(cacheValue))
     }
 

--- a/skills/cocache/references/custom-implementation.md
+++ b/skills/cocache/references/custom-implementation.md
@@ -63,12 +63,16 @@ class RedissonClientSideCache<V>(
         if (cacheValue.isExpired) {
             return
         }
-        if (cacheValue.isForever || cacheValue.isMissingGuard) {
+        if (cacheValue.isForever) {
             cache[key] = cacheValue
             return
         }
 
-        cache.put(key, cacheValue, cacheValue.expiredDuration.seconds, TimeUnit.SECONDS)
+        val ttlSeconds = cacheValue.expiredDuration.seconds
+        if (ttlSeconds <= 0) {
+            return
+        }
+        cache.put(key, cacheValue, ttlSeconds, TimeUnit.SECONDS)
     }
 
     override fun evict(key: String) {
@@ -341,8 +345,8 @@ class UserServiceCacheSource(
             val user = userService.findById(key)
             user?.let { DefaultCacheValue.forever(it) }
         } catch (e: Exception) {
-            // Return missing guard to prevent cache penetration
-            DefaultCacheValue.missingGuard()
+            // Use a short-lived missing guard for transient failures.
+            DefaultCacheValue.missingGuard<CacheValue<User>>(ttl = 30)
         }
     }
 }

--- a/skills/cocache/references/custom-implementation.md
+++ b/skills/cocache/references/custom-implementation.md
@@ -1,5 +1,14 @@
 # Custom Cache Implementations
 
+## Contents
+
+- [Custom ClientSideCache](#custom-clientsidecache)
+- [Custom DistributedCache](#custom-distributedcache)
+- [Custom CacheEvictedEventBus](#custom-cacheevictedeventbus)
+- [Custom KeyConverter](#custom-keyconverter)
+- [Custom CacheSource](#custom-cachesource)
+- [Registering Custom Implementations](#registering-custom-implementations)
+
 This guide covers creating custom implementations of CoCache's core interfaces: `ClientSideCache`, `DistributedCache`, and `CacheEvictedEventBus`.
 
 ## Custom ClientSideCache
@@ -31,7 +40,7 @@ class RedissonClientSideCache<V>(
 
     override fun getCache(key: String): CacheValue<V>? {
         val cacheValue = cache[key] ?: return null
-        if (cacheValue.isExpired()) {
+        if (cacheValue.isExpired) {
             cache.remove(key)
             return null
         }
@@ -43,7 +52,7 @@ class RedissonClientSideCache<V>(
     }
 
     override fun set(key: String, value: V) {
-        setCache(key, DefaultCacheValue(value))
+        setCache(key, DefaultCacheValue.forever(value))
     }
 
     override fun set(key: String, ttlAt: Long, value: V) {
@@ -51,27 +60,22 @@ class RedissonClientSideCache<V>(
     }
 
     override fun setCache(key: String, cacheValue: CacheValue<V>) {
-        if (cacheValue.isMissingGuard) {
-            cache[key] = cacheValue
-        } else {
-            val ttl = cacheValue.ttlAt - System.currentTimeMillis() / 1000
-            if (ttl > 0) {
-                cache.put(key, cacheValue, ttl, TimeUnit.SECONDS)
-            }
+        if (cacheValue.isExpired) {
+            return
         }
+        if (cacheValue.isForever || cacheValue.isMissingGuard) {
+            cache[key] = cacheValue
+            return
+        }
+
+        cache.put(key, cacheValue, cacheValue.expiredDuration.seconds, TimeUnit.SECONDS)
     }
 
     override fun evict(key: String) {
         cache.remove(key)
     }
 
-    override fun clear() {
-        cache.clear()
-    }
-
-    private fun CacheValue<V>.isExpired(): Boolean {
-        return ttlAt < System.currentTimeMillis() / 1000
-    }
+    override fun clear() = cache.clear()
 }
 ```
 
@@ -86,8 +90,8 @@ class RedissonClientSideCacheTest : ClientSideCacheSpec<String>() {
         return RedissonClientSideCache(Redisson.create().getMapCache("test"))
     }
 
-    override fun createCacheEntry(): CacheValue<String> {
-        return DefaultCacheValue("test_value")
+    override fun createCacheEntry(): Pair<String, String> {
+        return UUID.randomUUID().toString() to "test_value"
     }
 }
 ```
@@ -116,7 +120,9 @@ interface DistributedCache<V> : ComputedCache<String, V>, AutoCloseable {
 class MemcachedDistributedCache<V>(
     private val cacheName: String,
     private val client: MemcachedClient,
-    private val codec: Codec<V>
+    private val codec: Codec<V>,
+    override val ttl: Long = CoCache.DEFAULT_TTL,
+    override val ttlAmplitude: Long = CoCache.DEFAULT_TTL_AMPLITUDE
 ) : DistributedCache<V> {
 
     private val keyPrefix = "$cacheName:"
@@ -131,7 +137,7 @@ class MemcachedDistributedCache<V>(
     }
 
     override fun set(key: String, value: V) {
-        setCache(key, DefaultCacheValue(value))
+        setCache(key, DefaultCacheValue.forever(value))
     }
 
     override fun set(key: String, ttlAt: Long, value: V) {
@@ -139,10 +145,11 @@ class MemcachedDistributedCache<V>(
     }
 
     override fun setCache(key: String, cacheValue: CacheValue<V>) {
-        val ttl = (cacheValue.ttlAt - System.currentTimeMillis() / 1000).toInt()
-        if (ttl > 0) {
-            client.set("$keyPrefix$key", ttl, codec.encode(cacheValue))
+        if (cacheValue.isExpired) {
+            return
         }
+        val ttlSeconds = if (cacheValue.isForever) 0 else cacheValue.expiredDuration.seconds.toInt()
+        client.set("$keyPrefix$key", ttlSeconds, codec.encode(cacheValue))
     }
 
     override fun evict(key: String) {
@@ -166,8 +173,8 @@ class MemcachedDistributedCacheTest : DistributedCacheSpec<String>() {
         return MemcachedDistributedCache("test", memcachedClient, StringCodec())
     }
 
-    override fun createCacheEntry(): CacheValue<String> {
-        return DefaultCacheValue("test_value")
+    override fun createCacheEntry(): Pair<String, String> {
+        return UUID.randomUUID().toString() to "test_value"
     }
 }
 ```
@@ -192,7 +199,7 @@ interface CacheEvictedEventBus {
 data class CacheEvictedEvent(
     val cacheName: String,    // which cache was evicted
     val key: String,          // the evicted key
-    val clientId: String      // which instance performed the eviction
+    val publisherId: String   // which instance performed the eviction
 )
 ```
 
@@ -257,8 +264,8 @@ class KafkaCacheEvictedEventBusTest : CacheEvictedEventBusSpec() {
 ### Interface
 
 ```kotlin
-interface KeyConverter<K> {
-    fun asKey(key: K): String
+fun interface KeyConverter<K> {
+    fun toStringKey(sourceKey: K): String
 }
 ```
 
@@ -275,10 +282,10 @@ class CompositeKeyConverter<K>(
     private val separator: String = ":"
 ) : KeyConverter<K> {
 
-    override fun asKey(key: K): String {
-        return when (key) {
-            is Pair<*, *> -> "$prefix${key.first}$separator${key.second}"
-            else -> "$prefix$key"
+    override fun toStringKey(sourceKey: K): String {
+        return when (sourceKey) {
+            is Pair<*, *> -> "$prefix${sourceKey.first}$separator${sourceKey.second}"
+            else -> "$prefix$sourceKey"
         }
     }
 }
@@ -303,12 +310,14 @@ interface CacheSource<K, V> {
 ### Implementation Patterns
 
 ```kotlin
-// Pattern 1: Using CacheSource functional interface
+// Pattern 1: Inline CacheSource implementation
 @Bean("UserCache.CacheSource")
 fun userCacheSource(userRepository: UserRepository): CacheSource<String, User> {
-    return CacheSource { key ->
-        userRepository.findById(key).orElse(null)?.let {
-            DefaultCacheValue(it, ttl = 300)  // 5 min TTL
+    return object : CacheSource<String, User> {
+        override fun loadCacheValue(key: String): CacheValue<User>? {
+            return userRepository.findById(key).orElse(null)?.let {
+                DefaultCacheValue.ttlAt(it, ttl = 300)  // 5 min TTL
+            }
         }
     }
 }
@@ -322,7 +331,7 @@ class UserServiceCacheSource(
     override fun loadCacheValue(key: String): CacheValue<User>? {
         return try {
             val user = userService.findById(key)
-            user?.let { DefaultCacheValue(it) }
+            user?.let { DefaultCacheValue.forever(it) }
         } catch (e: Exception) {
             // Return missing guard to prevent cache penetration
             DefaultCacheValue.missingGuard()

--- a/skills/cocache/references/join-cache.md
+++ b/skills/cocache/references/join-cache.md
@@ -1,5 +1,16 @@
 # JoinCache Guide
 
+## Contents
+
+- [When to Use JoinCache](#when-to-use-joincache)
+- [How It Works](#how-it-works)
+- [Creating a JoinCache](#creating-a-joincache)
+- [JoinKeyExtractor Resolution](#joinkeyextractor-resolution)
+- [JoinValue Structure](#joinvalue-structure)
+- [Nested JoinCache](#nested-joincache)
+- [Eviction in JoinCache](#eviction-in-joincache)
+- [Common Patterns](#common-patterns)
+
 JoinCache composes two independent caches into a single logical view. It retrieves a primary value, extracts a join key from it, then fetches a secondary value from another cache.
 
 ## When to Use JoinCache

--- a/skills/cocache/references/setup.md
+++ b/skills/cocache/references/setup.md
@@ -214,13 +214,26 @@ For plain Spring projects, use `cocache-spring` directly:
 class CacheConfig {
 
     @Bean
-    fun distributedCache(redisTemplate: StringRedisTemplate): DistributedCache<String> {
-        return RedisDistributedCache(redisTemplate, StringToStringCodecExecutor(redisTemplate))
+    fun distributedCache(
+        redisTemplate: StringRedisTemplate,
+        objectMapper: ObjectMapper
+    ): DistributedCache<User> {
+        val codecExecutor = ObjectToJsonCodecExecutor<User>(
+            User::class.java,
+            redisTemplate,
+            objectMapper
+        )
+        return RedisDistributedCache(redisTemplate, codecExecutor)
     }
 
     @Bean
     fun clientSideCache(): ClientSideCache<User> {
-        return MapClientSideCache()
+        return CaffeineClientSideCache(
+            Caffeine.newBuilder()
+                .maximumSize(100_000)
+                .expireAfterAccess(Duration.ofMinutes(30))
+                .build<String, CacheValue<User>>()
+        )
     }
 
     @Bean

--- a/skills/cocache/references/setup.md
+++ b/skills/cocache/references/setup.md
@@ -1,5 +1,17 @@
 # CoCache Project Setup Guide
 
+## Contents
+
+- [Dependencies](#dependencies)
+- [Module Selection](#module-selection)
+- [Minimal Configuration](#minimal-configuration)
+- [Step-by-Step Setup](#step-by-step-setup)
+- [Without Spring Boot](#without-spring-boot)
+- [Single-Instance Setup (No Redis)](#single-instance-setup-no-redis)
+- [Spring Cache Bridge](#spring-cache-bridge)
+- [Actuator Endpoints](#actuator-endpoints)
+- [Disabling CoCache](#disabling-cocache)
+
 ## Dependencies
 
 ### Gradle (Kotlin DSL)
@@ -109,8 +121,8 @@ That's it. CoCache auto-configures:
 plugins {
     id("org.springframework.boot") version "4.0.5"
     id("io.spring.dependency-management") version "1.1.7"
-    kotlin("jvm") version "2.1.20"
-    kotlin("plugin.spring") version "2.1.20"
+    kotlin("jvm") version "2.3.20"
+    kotlin("plugin.spring") version "2.3.20"
 }
 
 dependencies {
@@ -151,18 +163,22 @@ class CacheSourceConfig {
 
     @Bean("UserCache.CacheSource")
     fun userCacheSource(userRepository: UserRepository): CacheSource<String, User> {
-        return CacheSource { key ->
-            userRepository.findById(key).orElse(null)?.let {
-                DefaultCacheValue(it)
+        return object : CacheSource<String, User> {
+            override fun loadCacheValue(key: String): CacheValue<User>? {
+                return userRepository.findById(key).orElse(null)?.let {
+                    DefaultCacheValue.forever(it)
+                }
             }
         }
     }
 
     @Bean("ProductCache.CacheSource")
     fun productCacheSource(productRepository: ProductRepository): CacheSource<String, Product> {
-        return CacheSource { key ->
-            productRepository.findById(key).orElse(null)?.let {
-                DefaultCacheValue(it)
+        return object : CacheSource<String, Product> {
+            override fun loadCacheValue(key: String): CacheValue<Product>? {
+                return productRepository.findById(key).orElse(null)?.let {
+                    DefaultCacheValue.forever(it)
+                }
             }
         }
     }
@@ -198,13 +214,13 @@ For plain Spring projects, use `cocache-spring` directly:
 class CacheConfig {
 
     @Bean
-    fun distributedCache(): DistributedCache<String> {
-        return RedisDistributedCache("user", redisTemplate)
+    fun distributedCache(redisTemplate: StringRedisTemplate): DistributedCache<String> {
+        return RedisDistributedCache(redisTemplate, StringToStringCodecExecutor(redisTemplate))
     }
 
     @Bean
     fun clientSideCache(): ClientSideCache<User> {
-        return GuavaClientSideCache(maximumSize = 100_000)
+        return MapClientSideCache()
     }
 
     @Bean
@@ -230,12 +246,37 @@ class MyApp {
 
     @Bean
     fun distributedCache(): DistributedCache<User> {
-        return MapClientSideCache<User>()  // use local map as "distributed" cache
+        return MockDistributedCache<User>()  // in-memory distributed layer for development/testing
     }
 }
 ```
 
 Note: This loses cross-instance coherence. Only use for development/testing.
+
+## Spring Cache Bridge
+
+`cocache-spring-cache` integrates CoCache with Spring's `@Cacheable` abstraction. When `@EnableCaching` is present, CoCache can auto-configure `CoCacheManager`:
+
+```kotlin
+@Cacheable(cacheNames = ["userCache"])
+fun getUser(id: String): User? {
+    return userRepository.findById(id).orElse(null)
+}
+```
+
+The call routes through CoCache's two-level cache.
+
+## Actuator Endpoints
+
+When Spring Actuator is on the classpath:
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/actuator/cocache` | GET | List all coherent caches |
+| `/actuator/cocache/{name}` | GET | Cache stats |
+| `/actuator/cocache/{name}/{key}` | GET | Get a cache entry |
+| `/actuator/cocache/{name}/{key}` | DELETE | Evict a cache entry |
+| `/actuator/cocacheClient` | GET | Client-side cache info |
 
 ## Disabling CoCache
 

--- a/skills/cocache/references/setup.md
+++ b/skills/cocache/references/setup.md
@@ -224,8 +224,20 @@ class CacheConfig {
     }
 
     @Bean
-    fun cacheEvictedEventBus(): CacheEvictedEventBus {
-        return RedisCacheEvictedEventBus(redisTemplate)
+    fun redisMessageListenerContainer(
+        redisConnectionFactory: RedisConnectionFactory
+    ): RedisMessageListenerContainer {
+        return RedisMessageListenerContainer().apply {
+            setConnectionFactory(redisConnectionFactory)
+        }
+    }
+
+    @Bean
+    fun cacheEvictedEventBus(
+        redisTemplate: StringRedisTemplate,
+        redisMessageListenerContainer: RedisMessageListenerContainer
+    ): CacheEvictedEventBus {
+        return RedisCacheEvictedEventBus(redisTemplate, redisMessageListenerContainer)
     }
 }
 ```

--- a/skills/cocache/references/testing.md
+++ b/skills/cocache/references/testing.md
@@ -1,5 +1,18 @@
 # CoCache Testing Guide
 
+## Contents
+
+- [Test Specs Overview](#test-specs-overview)
+- [Testing a ClientSideCache Implementation](#testing-a-clientsidecache-implementation)
+- [Testing a DistributedCache Implementation](#testing-a-distributedcache-implementation)
+- [Testing a CoherentCache (Two-Level Cache)](#testing-a-coherentcache-two-level-cache)
+- [Testing CacheEvictedEventBus](#testing-cacheevictedeventbus)
+- [Testing Cross-Instance Coherence](#testing-cross-instance-coherence)
+- [Testing with Redis (Integration Tests)](#testing-with-redis-integration-tests)
+- [Assertion Style](#assertion-style)
+- [Writing Custom Test Cases](#writing-custom-test-cases)
+- [Test Dependencies](#test-dependencies)
+
 CoCache provides abstract test specs in `cocache-test` that verify cache contracts. Extend the appropriate spec, implement factory methods, and you get comprehensive test coverage for free.
 
 ## Test Specs Overview
@@ -63,42 +76,26 @@ class MyDistributedCacheTest : DistributedCacheSpec<String>() {
 ## Testing a CoherentCache (Two-Level Cache)
 
 ```kotlin
-import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.api.client.ClientSideCache
+import me.ahoo.cache.client.MapClientSideCache
 import me.ahoo.cache.consistency.CacheEvictedEventBus
-import me.ahoo.cache.core.DefaultCacheValue
-import me.ahoo.cache.core.converter.ToStringKeyConverter
+import me.ahoo.cache.consistency.GuavaCacheEvictedEventBus
+import me.ahoo.cache.converter.KeyConverter
+import me.ahoo.cache.converter.ToStringKeyConverter
 import me.ahoo.cache.distributed.DistributedCache
+import me.ahoo.cache.distributed.mock.MockDistributedCache
 import me.ahoo.cache.test.DefaultCoherentCacheSpec
+import java.util.*
 
 class MyCoherentCacheTest : DefaultCoherentCacheSpec<String, String>() {
 
-    override fun createCache(): me.ahoo.cache.consistency.CoherentCache<String, String> {
-        return DefaultCoherentCache(
-            cacheName = "testCache",
-            keyConverter = createKeyConverter(),
-            clientSideCache = createClientSideCache(),
-            distributedCache = createDistributedCache(),
-            cacheSource = CacheSource.noOp(),
-            cacheEvictedEventBus = createCacheEvictedEventBus()
-        )
-    }
+    override fun createKeyConverter(): KeyConverter<String> = ToStringKeyConverter("test:")
 
-    override fun createKeyConverter(): me.ahoo.cache.api.KeyConverter<String> {
-        return ToStringKeyConverter("test:")
-    }
+    override fun createClientSideCache(): ClientSideCache<String> = MapClientSideCache()
 
-    override fun createClientSideCache(): ClientSideCache<String> {
-        return GuavaClientSideCache(maximumSize = 1000)
-    }
+    override fun createDistributedCache(): DistributedCache<String> = MockDistributedCache()
 
-    override fun createDistributedCache(): DistributedCache<String> {
-        return MyDistributedCache()
-    }
-
-    override fun createCacheEvictedEventBus(): CacheEvictedEventBus {
-        return GuavaCacheEvictedEventBus()
-    }
+    override fun createCacheEvictedEventBus(): CacheEvictedEventBus = GuavaCacheEvictedEventBus()
 
     override fun createCacheName(): String = "testCache"
 
@@ -120,7 +117,7 @@ This tests:
 
 ```kotlin
 import me.ahoo.cache.consistency.CacheEvictedEventBus
-import me.ahoo.cache.core.GuavaCacheEvictedEventBus
+import me.ahoo.cache.consistency.GuavaCacheEvictedEventBus
 import me.ahoo.cache.test.CacheEvictedEventBusSpec
 
 class MyEventBusTest : CacheEvictedEventBusSpec() {
@@ -138,33 +135,28 @@ Tests:
 ## Testing Cross-Instance Coherence
 
 ```kotlin
-import me.ahoo.cache.api.CacheValue
+import me.ahoo.cache.api.client.ClientSideCache
+import me.ahoo.cache.client.MapClientSideCache
 import me.ahoo.cache.consistency.CacheEvictedEventBus
-import me.ahoo.cache.core.DefaultCacheValue
+import me.ahoo.cache.consistency.GuavaCacheEvictedEventBus
+import me.ahoo.cache.converter.KeyConverter
+import me.ahoo.cache.converter.ToStringKeyConverter
 import me.ahoo.cache.distributed.DistributedCache
+import me.ahoo.cache.distributed.mock.MockDistributedCache
 import me.ahoo.cache.test.MultipleInstanceSyncSpec
+import java.util.*
 
 class MyMultiInstanceTest : MultipleInstanceSyncSpec<String, String>() {
 
-    override fun createDistributedCache(): DistributedCache<String> {
-        return MyDistributedCache()
-    }
+    override fun createKeyConverter(): KeyConverter<String> = ToStringKeyConverter("test:")
 
-    override fun createCacheEvictedEventBus(): CacheEvictedEventBus {
-        return GuavaCacheEvictedEventBus()
-    }
+    override fun createClientSideCache(): ClientSideCache<String> = MapClientSideCache()
 
-    override fun createCache(): me.ahoo.cache.consistency.CoherentCache<String, String> {
-        // Create a CoherentCache instance
-        return DefaultCoherentCache(
-            cacheName = "testCache",
-            keyConverter = ToStringKeyConverter("test:"),
-            clientSideCache = GuavaClientSideCache(maximumSize = 1000),
-            distributedCache = createDistributedCache(),
-            cacheSource = CacheSource.noOp(),
-            cacheEvictedEventBus = createCacheEvictedEventBus()
-        )
-    }
+    override fun createDistributedCache(): DistributedCache<String> = MockDistributedCache()
+
+    override fun createCacheEvictedEventBus(): CacheEvictedEventBus = GuavaCacheEvictedEventBus()
+
+    override fun createCacheName(): String = "testCache"
 
     override fun createCacheEntry(): Pair<String, String> {
         return UUID.randomUUID().toString() to UUID.randomUUID().toString()
@@ -178,29 +170,47 @@ This creates two CoherentCache instances sharing the same DistributedCache and E
 
 ## Testing with Redis (Integration Tests)
 
-For Redis-based tests, use Testcontainers:
+Redis integration tests require a running Redis instance. CI provides Redis as a service container; local runs should start Redis first.
 
 ```kotlin
-@Testcontainers
+import me.ahoo.cache.distributed.DistributedCache
+import me.ahoo.cache.spring.redis.RedisDistributedCache
+import me.ahoo.cache.spring.redis.codec.StringToStringCodecExecutor
+import me.ahoo.cache.test.DistributedCacheSpec
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import java.util.*
+
 class RedisDistributedCacheTest : DistributedCacheSpec<String>() {
 
-    companion object {
-        @Container
-        val redis = GenericContainer(DockerImageName.parse("redis:7"))
-            .withExposedPorts(6379)
-    }
+    private lateinit var stringRedisTemplate: StringRedisTemplate
+    private lateinit var codecExecutor: StringToStringCodecExecutor
+    private lateinit var lettuceConnectionFactory: LettuceConnectionFactory
 
     override fun createCache(): DistributedCache<String> {
-        val factory = LettuceConnectionFactory(
-            RedisStandaloneConfiguration("localhost", redis.firstMappedPort)
-        )
-        factory.afterPropertiesSet()
-        val template = StringRedisTemplate(factory)
-        return RedisDistributedCache("test", template)
+        return RedisDistributedCache(stringRedisTemplate, codecExecutor)
     }
 
     override fun createCacheEntry(): Pair<String, String> {
         return UUID.randomUUID().toString() to UUID.randomUUID().toString()
+    }
+
+    @BeforeEach
+    override fun setup() {
+        lettuceConnectionFactory = LettuceConnectionFactory(RedisStandaloneConfiguration())
+        lettuceConnectionFactory.afterPropertiesSet()
+        stringRedisTemplate = StringRedisTemplate(lettuceConnectionFactory)
+        stringRedisTemplate.afterPropertiesSet()
+        codecExecutor = StringToStringCodecExecutor(stringRedisTemplate)
+        super.setup()
+    }
+
+    @AfterEach
+    fun destroy() {
+        lettuceConnectionFactory.destroy()
     }
 }
 ```
@@ -240,7 +250,7 @@ class MyCacheTest : ClientSideCacheSpec<String>() {
         repeat(100) { i ->
             thread {
                 try {
-                    cache["key_$i"] = DefaultCacheValue("value_$i")
+                    cache["key_$i"] = "value_$i"
                     cache.getCache("key_$i").assert().isNotNull()
                 } catch (e: Exception) {
                     errors.add(i)

--- a/skills/plugins.json
+++ b/skills/plugins.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": 1,
+  "plugins": [
+    {
+      "name": "ahoo-cocache-skills",
+      "description": "CoCache skills for implementing two-level distributed coherent caches, cache proxy interfaces, JoinCache composition, and Redis/Spring Boot integration in Java/Kotlin projects.",
+      "skills": {
+        "include": [
+          "*"
+        ],
+        "exclude": [
+          "*-workspace"
+        ]
+      },
+      "keywords": [
+        "cocache",
+        "coherent-cache",
+        "distributed-cache",
+        "two-level-cache",
+        "spring-boot",
+        "redis",
+        "kotlin",
+        "java",
+        "join-cache",
+        "cache-coherence"
+      ],
+      "category": "development",
+      "interface": {
+        "displayName": "Ahoo CoCache Skills",
+        "capabilities": [
+          "Skills"
+        ],
+        "defaultPrompt": "Help me use CoCache for two-level distributed coherent caching, cache proxy interfaces, JoinCache, Redis, and Spring Boot integration."
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `skills/plugins.json` as platform-neutral plugin publishing metadata for the CoCache skill source.
- Slim `skills/cocache/SKILL.md` into a concise routing guide and move deeper guidance into references.
- Add `agents/openai.yaml` UI metadata and refresh reference examples to match current CoCache APIs and testing contracts.

## Validation

- `/usr/bin/python3 /Users/ahoo/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/cocache`
- `jq empty skills/plugins.json && jq -e '.schemaVersion == 1 and (.plugins | length == 1) and (.plugins[0].name == "ahoo-cocache-skills") and (.plugins[0].skills.include == ["*"]) and (.plugins[0].skills.exclude == ["*-workspace"])' skills/plugins.json`
- `git diff --check`
- `./gradlew check` after starting a temporary local Redis on `localhost:6379` for Redis integration tests
