### PR TITLE
fix(cache): enforce cache contract edge cases

### DIFF
--- a/.github/workflows/package-deploy.yml
+++ b/.github/workflows/package-deploy.yml
@@ -17,7 +17,35 @@ on:
     types: [created]
 
 jobs:
+  verify:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: github
+          settings-path: ${{ github.workspace }}
+
+      - name: Check
+        run: ./gradlew clean check
+
   github-deploy:
+    needs: verify
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -42,6 +70,7 @@ jobs:
           SIGNING_SECRETKEY: ${{ secrets.SIGNING_SECRETKEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
   central-deploy:
+    needs: verify
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/CaffeineClientSideCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/CaffeineClientSideCache.kt
@@ -36,6 +36,7 @@ class CaffeineClientSideCache<V>(
 
     override fun setCache(key: String, value: CacheValue<V>) {
         if (value.isExpired) {
+            evict(key)
             return
         }
         caffeineCache.put(key, value)

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/GuavaClientSideCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/GuavaClientSideCache.kt
@@ -35,6 +35,7 @@ class GuavaClientSideCache<V>(
 
     override fun setCache(key: String, value: CacheValue<V>) {
         if (value.isExpired) {
+            evict(key)
             return
         }
         guavaCache.put(key, value)

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/client/MapClientSideCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/client/MapClientSideCache.kt
@@ -32,6 +32,7 @@ class MapClientSideCache<V>(
 
     override fun setCache(key: String, value: CacheValue<V>) {
         if (value.isExpired) {
+            evict(key)
             return
         }
         cacheMap[key] = value

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/DefaultCoherentCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/consistency/DefaultCoherentCache.kt
@@ -135,12 +135,18 @@ class DefaultCoherentCache<K, V>(
     }
 
     private fun setCache(cacheKey: String, cacheValue: CacheValue<V>) {
+        if (cacheValue.isExpired) {
+            clientSideCache.evict(cacheKey)
+            distributedCache.evict(cacheKey)
+            return
+        }
         clientSideCache.setCache(cacheKey, cacheValue)
         distributedCache.setCache(cacheKey, cacheValue)
     }
 
     override fun setCache(key: K, value: CacheValue<V>) {
         if (value.isExpired) {
+            evict(key)
             return
         }
         val cacheKey = keyConverter.toStringKey(key)

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/distributed/mock/MockDistributedCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/distributed/mock/MockDistributedCache.kt
@@ -34,6 +34,7 @@ class MockDistributedCache<V>(
 
     override fun setCache(key: String, value: CacheValue<V>) {
         if (value.isExpired) {
+            evict(key)
             return
         }
         cacheMap[key] = value

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/join/SimpleJoinCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/join/SimpleJoinCache.kt
@@ -14,7 +14,6 @@ package me.ahoo.cache.join
 
 import me.ahoo.cache.ComputedCache
 import me.ahoo.cache.DefaultCacheValue
-import me.ahoo.cache.DefaultCacheValue.Companion.missingGuard
 import me.ahoo.cache.api.Cache
 import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.api.join.JoinCache
@@ -39,13 +38,19 @@ class SimpleJoinCache<K1, V1, K2, V2>(
     @Suppress("ReturnCount")
     override fun getCache(key: K1): CacheValue<JoinValue<V1, K2, V2>>? {
         val firstCacheValue = firstCache.getCache(key) ?: return null
+        if (firstCacheValue.isExpired) {
+            return null
+        }
         if (firstCacheValue.isMissingGuard) {
-            return missingGuard()
+            return DefaultCacheValue(DefaultJoinValue.missingGuardValue(), firstCacheValue.ttlAt)
         }
         val joinKey = joinKeyExtractor.extract(firstCacheValue.value)
         val secondCacheValue = joinCache.getCache(joinKey)
-        val joinValue = DefaultJoinValue(firstCacheValue.value, joinKey, secondCacheValue?.value)
-        val ttlAt = getJoinTtlAt(firstCacheValue.ttlAt, secondCacheValue?.ttlAt)
+        val availableSecondCacheValue = secondCacheValue?.takeUnless {
+            it.isMissingGuard || it.isExpired
+        }
+        val joinValue = DefaultJoinValue(firstCacheValue.value, joinKey, availableSecondCacheValue?.value)
+        val ttlAt = getJoinTtlAt(firstCacheValue.ttlAt, availableSecondCacheValue?.ttlAt)
         return DefaultCacheValue(value = joinValue, ttlAt = ttlAt)
     }
 
@@ -62,7 +67,7 @@ class SimpleJoinCache<K1, V1, K2, V2>(
     @Suppress("UNCHECKED_CAST")
     override fun setCache(key: K1, value: CacheValue<JoinValue<V1, K2, V2>>) {
         if (value.isMissingGuard) {
-            firstCache.setCache(key, missingGuard())
+            firstCache.setCache(key, DefaultCacheValue(DefaultCacheValue.missingGuardValue(), value.ttlAt))
             return
         }
         val firstCacheValue = DefaultCacheValue(value = value.value.firstValue, ttlAt = value.ttlAt)

--- a/cocache-core/src/main/kotlin/me/ahoo/cache/join/SimpleJoinCache.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/join/SimpleJoinCache.kt
@@ -50,7 +50,10 @@ class SimpleJoinCache<K1, V1, K2, V2>(
             it.isMissingGuard || it.isExpired
         }
         val joinValue = DefaultJoinValue(firstCacheValue.value, joinKey, availableSecondCacheValue?.value)
-        val ttlAt = getJoinTtlAt(firstCacheValue.ttlAt, availableSecondCacheValue?.ttlAt)
+        val secondTtlAt = secondCacheValue?.takeUnless {
+            it.isExpired
+        }?.ttlAt
+        val ttlAt = getJoinTtlAt(firstCacheValue.ttlAt, secondTtlAt)
         return DefaultCacheValue(value = joinValue, ttlAt = ttlAt)
     }
 
@@ -66,6 +69,10 @@ class SimpleJoinCache<K1, V1, K2, V2>(
 
     @Suppress("UNCHECKED_CAST")
     override fun setCache(key: K1, value: CacheValue<JoinValue<V1, K2, V2>>) {
+        if (value.isExpired) {
+            evict(key)
+            return
+        }
         if (value.isMissingGuard) {
             firstCache.setCache(key, DefaultCacheValue(DefaultCacheValue.missingGuardValue(), value.ttlAt))
             return

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/join/SimpleJoinCacheTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/join/SimpleJoinCacheTest.kt
@@ -12,6 +12,7 @@
  */
 package me.ahoo.cache.join
 
+import me.ahoo.cache.ComputedTtlAt
 import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.MissingGuard
 import me.ahoo.cache.api.Cache
@@ -118,6 +119,68 @@ internal class SimpleJoinCacheTest : CacheSpec<String, JoinValue<Order, String, 
     }
 
     @Test
+    fun getWhenSecondValueIsAbsentKeepsFirstValue() {
+        val orderId = UuidGenerator.INSTANCE.generateAsString()
+        val order = Order(orderId)
+        orderCache.setCache(orderId, DefaultCacheValue.forever(order))
+
+        val actual = cache[orderId]
+
+        actual.assert().isNotNull()
+        actual!!.firstValue.assert().isEqualTo(order)
+        actual.joinKey.assert().isEqualTo(orderId)
+        actual.secondValue.assert().isNull()
+    }
+
+    @Test
+    fun getWhenSecondValueIsExpiredTreatsSecondAsAbsent() {
+        val orderId = UuidGenerator.INSTANCE.generateAsString()
+        val order = Order(orderId)
+        val firstCache = RawCache<Order>(DefaultCacheValue.forever(order))
+        val secondCache = RawCache<OrderAddress>(DefaultCacheValue(OrderAddress(order.id), ComputedTtlAt.at(-5)))
+        val cache = SimpleJoinCache(firstCache, secondCache) { firstValue -> firstValue.id }
+
+        val actual = cache[orderId]
+
+        actual.assert().isNotNull()
+        actual!!.firstValue.assert().isEqualTo(order)
+        actual.joinKey.assert().isEqualTo(orderId)
+        actual.secondValue.assert().isNull()
+    }
+
+    @Test
+    fun getWhenFirstValueIsExpiredReturnsMiss() {
+        val orderId = UuidGenerator.INSTANCE.generateAsString()
+        val firstCache = RawCache<Order>(DefaultCacheValue(Order(orderId), ComputedTtlAt.at(-5)))
+        val secondCache = RawCache<OrderAddress>()
+        val cache = SimpleJoinCache(firstCache, secondCache) { firstValue -> firstValue.id }
+
+        cache.getCache(orderId).assert().isNull()
+    }
+
+    @Test
+    fun setJoinValueWithoutSecondValueDoesNotPopulateJoinCache() {
+        val orderId = UuidGenerator.INSTANCE.generateAsString()
+        val order = Order(orderId)
+        val joinValue: JoinValue<Order, String, OrderAddress> = DefaultJoinValue(order, orderId, null)
+
+        cache.setCache(orderId, DefaultCacheValue.forever(joinValue))
+
+        orderCache[orderId].assert().isEqualTo(order)
+        orderAddressCache.getCache(orderId).assert().isNull()
+    }
+
+    @Test
+    fun evictWhenFirstValueIsAbsentStillCompletes() {
+        val orderId = UuidGenerator.INSTANCE.generateAsString()
+
+        cache.evict(orderId)
+
+        orderCache.getCache(orderId).assert().isNull()
+        orderAddressCache.getCache(orderId).assert().isNull()
+    }
+
+    @Test
     fun setMissingTtlPreservesTtlAtInFirstCache() {
         val (key, _) = createCacheEntry()
         val missingValue = DefaultCacheValue.missingGuard<CacheValue<JoinValue<Order, String, OrderAddress>>>(
@@ -134,6 +197,42 @@ internal class SimpleJoinCacheTest : CacheSpec<String, JoinValue<Order, String, 
 data class Order(val id: String)
 
 data class OrderAddress(val orderId: String)
+
+private class RawCache<V>(
+    private var cacheValue: CacheValue<V>? = null
+) : Cache<String, V> {
+    override fun getCache(key: String): CacheValue<V>? {
+        return cacheValue
+    }
+
+    override fun get(key: String): V? {
+        return cacheValue?.takeUnless {
+            it.isMissingGuard || it.isExpired
+        }?.value
+    }
+
+    override fun getTtlAt(key: String): Long? {
+        return cacheValue?.takeUnless {
+            it.isMissingGuard
+        }?.ttlAt
+    }
+
+    override fun set(key: String, ttlAt: Long, value: V) {
+        cacheValue = DefaultCacheValue(value, ttlAt)
+    }
+
+    override fun set(key: String, value: V) {
+        cacheValue = DefaultCacheValue.forever(value)
+    }
+
+    override fun setCache(key: String, value: CacheValue<V>) {
+        cacheValue = value
+    }
+
+    override fun evict(key: String) {
+        cacheValue = null
+    }
+}
 
 @JoinCacheable(firstCacheName = "OrderAddress", joinCacheName = "Order")
 interface MockJoinCache : JoinCache<String, OrderAddress, String, Order>

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/join/SimpleJoinCacheTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/join/SimpleJoinCacheTest.kt
@@ -13,7 +13,9 @@
 package me.ahoo.cache.join
 
 import me.ahoo.cache.DefaultCacheValue
+import me.ahoo.cache.MissingGuard
 import me.ahoo.cache.api.Cache
+import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.api.annotation.JoinCacheable
 import me.ahoo.cache.api.join.JoinCache
 import me.ahoo.cache.api.join.JoinValue
@@ -98,6 +100,34 @@ internal class SimpleJoinCacheTest : CacheSpec<String, JoinValue<Order, String, 
 
         orderCache.getCache(key).assert().isNull()
         orderAddressCache.getCache(key).assert().isNull()
+    }
+
+    @Test
+    fun getWhenSecondValueIsMissingGuardTreatsSecondAsAbsent() {
+        val orderId = UuidGenerator.INSTANCE.generateAsString()
+        val order = Order(orderId)
+        orderCache.setCache(orderId, DefaultCacheValue.forever(order))
+        orderAddressCache.setCache(orderId, DefaultCacheValue.missingGuard())
+
+        val actual = cache[orderId]
+
+        actual.assert().isNotNull()
+        actual!!.firstValue.assert().isEqualTo(order)
+        actual.joinKey.assert().isEqualTo(orderId)
+        actual.secondValue.assert().isNull()
+    }
+
+    @Test
+    fun setMissingTtlPreservesTtlAtInFirstCache() {
+        val (key, _) = createCacheEntry()
+        val missingValue = DefaultCacheValue.missingGuard<CacheValue<JoinValue<Order, String, OrderAddress>>>(
+            missingGuard as MissingGuard,
+            5,
+        )
+
+        cache.setCache(key, missingValue)
+
+        orderCache.getCache(key)!!.ttlAt.assert().isEqualTo(missingValue.ttlAt)
     }
 }
 

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/join/SimpleJoinCacheTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/join/SimpleJoinCacheTest.kt
@@ -108,12 +108,14 @@ internal class SimpleJoinCacheTest : CacheSpec<String, JoinValue<Order, String, 
         val orderId = UuidGenerator.INSTANCE.generateAsString()
         val order = Order(orderId)
         orderCache.setCache(orderId, DefaultCacheValue.forever(order))
-        orderAddressCache.setCache(orderId, DefaultCacheValue.missingGuard())
+        val secondMissingGuard = DefaultCacheValue.missingGuard<CacheValue<OrderAddress>>(5)
+        orderAddressCache.setCache(orderId, secondMissingGuard)
 
-        val actual = cache[orderId]
+        val actualCacheValue = cache.getCache(orderId)
+        val actual = actualCacheValue!!.value
 
-        actual.assert().isNotNull()
-        actual!!.firstValue.assert().isEqualTo(order)
+        actualCacheValue.ttlAt.assert().isEqualTo(secondMissingGuard.ttlAt)
+        actual.firstValue.assert().isEqualTo(order)
         actual.joinKey.assert().isEqualTo(orderId)
         actual.secondValue.assert().isNull()
     }
@@ -168,6 +170,32 @@ internal class SimpleJoinCacheTest : CacheSpec<String, JoinValue<Order, String, 
 
         orderCache[orderId].assert().isEqualTo(order)
         orderAddressCache.getCache(orderId).assert().isNull()
+    }
+
+    @Test
+    fun setExpiredJoinValueEvictsPreviousJoinEntry() {
+        val orderId = UuidGenerator.INSTANCE.generateAsString()
+        val oldOrder = Order(orderId)
+        val oldAddress = OrderAddress(orderId)
+        cache.setCache(
+            orderId,
+            DefaultCacheValue.forever(DefaultJoinValue(oldOrder, orderId, oldAddress))
+        )
+        orderCache.getCache(orderId).assert().isNotNull()
+        orderAddressCache.getCache(orderId).assert().isNotNull()
+
+        val newJoinKey = UuidGenerator.INSTANCE.generateAsString()
+        val expiredJoinValue: JoinValue<Order, String, OrderAddress> = DefaultJoinValue(
+            Order(newJoinKey),
+            newJoinKey,
+            null,
+        )
+
+        cache.setCache(orderId, DefaultCacheValue(expiredJoinValue, ComputedTtlAt.at(-5)))
+
+        orderCache.getCache(orderId).assert().isNull()
+        orderAddressCache.getCache(orderId).assert().isNull()
+        orderAddressCache.getCache(newJoinKey).assert().isNull()
     }
 
     @Test

--- a/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfiguration.kt
+++ b/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfiguration.kt
@@ -45,6 +45,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration
+import org.springframework.cache.CacheManager
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -78,6 +79,7 @@ class CoCacheAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean(CacheManager::class)
     fun coCacheManager(cacheFactory: CacheFactory): CoCacheManager {
         return CoCacheManager(cacheFactory)
     }
@@ -177,6 +179,7 @@ class CoCacheAutoConfiguration {
     class CosIdHostAddressSupplierAutoConfiguration {
         @Bean
         @ConditionalOnBean(HostAddressSupplier::class)
+        @ConditionalOnMissingBean(ClientIdGenerator::class)
         fun inetUtilsHostClientIdGenerator(hostAddressSupplier: HostAddressSupplier): ClientIdGenerator {
             return HostClientIdGenerator {
                 hostAddressSupplier.hostAddress

--- a/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfigurationTest.kt
+++ b/cocache-spring-boot-starter/src/test/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheAutoConfigurationTest.kt
@@ -28,11 +28,14 @@ import me.ahoo.cache.spring.boot.starter.customize.UserPlaceholderCache
 import me.ahoo.cache.util.ClientIdGenerator
 import me.ahoo.cosid.machine.HostAddressSupplier
 import me.ahoo.cosid.machine.LocalHostAddressSupplier
+import me.ahoo.test.asserts.assert
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration
 import org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.cache.CacheManager
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager
 import org.springframework.data.redis.listener.RedisMessageListenerContainer
 
 internal class CoCacheAutoConfigurationTest {
@@ -103,6 +106,45 @@ internal class CoCacheAutoConfigurationTest {
                     .hasSingleBean(CacheEvictedEventBus::class.java)
                     .hasSingleBean(CacheFactory::class.java)
                 context.getBean(ClientIdGenerator::class.java).generate()
+            }
+    }
+
+    @Test
+    fun contextLoadsWithCustomClientIdGeneratorAndHostAddressSupplier() {
+        val customClientIdGenerator = object : ClientIdGenerator {
+            override fun generate(): String {
+                return "custom-client"
+            }
+        }
+
+        contextRunner
+            .withBean(HostAddressSupplier::class.java, { LocalHostAddressSupplier.INSTANCE })
+            .withBean(ClientIdGenerator::class.java, { customClientIdGenerator })
+            .withUserConfiguration(
+                JacksonAutoConfiguration::class.java,
+                DataRedisAutoConfiguration::class.java,
+                CoCacheAutoConfiguration::class.java
+            )
+            .run { context ->
+                context.getBeansOfType(ClientIdGenerator::class.java).size.assert().isOne()
+                context.getBean(ClientIdGenerator::class.java).assert().isEqualTo(customClientIdGenerator)
+            }
+    }
+
+    @Test
+    fun contextLoadsWithCustomCacheManager() {
+        val customCacheManager = ConcurrentMapCacheManager("custom")
+
+        contextRunner
+            .withBean(CacheManager::class.java, { customCacheManager })
+            .withUserConfiguration(
+                JacksonAutoConfiguration::class.java,
+                DataRedisAutoConfiguration::class.java,
+                CoCacheAutoConfiguration::class.java
+            )
+            .run { context ->
+                context.getBeansOfType(CacheManager::class.java).size.assert().isOne()
+                context.getBean(CacheManager::class.java).assert().isEqualTo(customCacheManager)
             }
     }
 }

--- a/cocache-spring-cache/src/main/kotlin/me/ahoo/cache/spring/cache/CoSpringCache.kt
+++ b/cocache-spring-cache/src/main/kotlin/me/ahoo/cache/spring/cache/CoSpringCache.kt
@@ -39,21 +39,38 @@ class CoSpringCache(
 
     override fun get(key: Any): SpringCache.ValueWrapper? {
         val cacheValue = delegate.getCache(key) ?: return null
+        if (cacheValue.isExpired) {
+            delegate.evict(key)
+            return null
+        }
+        if (cacheValue.isMissingGuard) {
+            return null
+        }
         return SpringCacheValueWrapper(cacheValue)
     }
 
     override fun <T : Any> get(key: Any, type: Class<T>?): T? {
-        return delegate.get(key) as T?
+        val value = get(key)?.get() ?: return null
+        if (type != null && !type.isInstance(value)) {
+            throw IllegalStateException(
+                "Cached value is not of required type [" + type.name + "]: " + value
+            )
+        }
+        return value as T
     }
 
+    @Suppress("TooGenericExceptionCaught")
     override fun <T : Any> get(key: Any, valueLoader: Callable<T>): T? {
-        val value = delegate.get(key)
-        if (value != null) {
-            return value as T
+        get(key)?.let {
+            return it.get() as T?
         }
-        val loadedValue = valueLoader.call()
-        delegate.set(key, loadedValue)
-        return loadedValue
+        return try {
+            val loadedValue = valueLoader.call()
+            delegate.set(key, loadedValue)
+            loadedValue
+        } catch (error: Throwable) {
+            throw SpringCache.ValueRetrievalException(key, valueLoader, error)
+        }
     }
 
     override fun put(key: Any, value: Any?) {
@@ -76,11 +93,10 @@ class CoSpringCache(
      * needed unwrapping via `CacheDelegated` — silently dropped `clear()`,
      * violating Spring's `Cache.clear()` contract.
      */
-    @Suppress("UNCHECKED_CAST")
     private fun clearDelegate(cache: Cache<*, *>) {
         // Unwrap proxy delegates first (plain cache proxies implement CacheDelegated).
         if (cache is CacheDelegated<*>) {
-            clearDelegate(cache.delegate as Cache<*, *>)
+            clearDelegate(cache.delegate)
             return
         }
         when (cache) {
@@ -97,22 +113,19 @@ class CoSpringCache(
     }
 
     override fun retrieve(key: Any): CompletableFuture<*>? {
-        return CompletableFuture.supplyAsync {
-            delegate.get(key)
-        }
+        val valueWrapper = get(key) ?: return null
+        return CompletableFuture.completedFuture(valueWrapper.get())
     }
 
     override fun <T : Any> retrieve(key: Any, valueLoader: Supplier<CompletableFuture<T>>): CompletableFuture<T> {
-        return CompletableFuture.supplyAsync {
-            delegate.get(key) as T?
-        }.thenCompose<T?> {
-            if (it != null) {
-                return@thenCompose CompletableFuture.completedFuture(it)
-            }
-            valueLoader.get().thenApply {
-                delegate.set(key, it)
-                it
-            }
+        get(key)?.let {
+            @Suppress("UNCHECKED_CAST")
+            return CompletableFuture.completedFuture(it.get() as T?)
+                as CompletableFuture<T>
+        }
+        return valueLoader.get().thenApply {
+            delegate.set(key, it)
+            it
         }
     }
 }

--- a/cocache-spring-cache/src/main/kotlin/me/ahoo/cache/spring/cache/CoSpringCache.kt
+++ b/cocache-spring-cache/src/main/kotlin/me/ahoo/cache/spring/cache/CoSpringCache.kt
@@ -113,19 +113,31 @@ class CoSpringCache(
     }
 
     override fun retrieve(key: Any): CompletableFuture<*>? {
-        val valueWrapper = get(key) ?: return null
-        return CompletableFuture.completedFuture(valueWrapper.get())
+        return retrieveValueWrapper(key)
     }
 
+    @Suppress("TooGenericExceptionCaught")
     override fun <T : Any> retrieve(key: Any, valueLoader: Supplier<CompletableFuture<T>>): CompletableFuture<T> {
-        get(key)?.let {
+        return retrieveValueWrapper(key).thenCompose { valueWrapper ->
+            if (valueWrapper == null) {
+                return@thenCompose try {
+                    valueLoader.get().thenApply {
+                        delegate.set(key, it)
+                        it
+                    }
+                } catch (error: Throwable) {
+                    CompletableFuture.failedFuture(error)
+                }
+            }
             @Suppress("UNCHECKED_CAST")
-            return CompletableFuture.completedFuture(it.get() as T?)
+            CompletableFuture.completedFuture(valueWrapper.get() as T?)
                 as CompletableFuture<T>
         }
-        return valueLoader.get().thenApply {
-            delegate.set(key, it)
-            it
+    }
+
+    private fun retrieveValueWrapper(key: Any): CompletableFuture<SpringCache.ValueWrapper?> {
+        return CompletableFuture.supplyAsync {
+            get(key)
         }
     }
 }

--- a/cocache-spring-cache/src/test/kotlin/me/ahoo/cache/spring/cache/CoSpringCacheTest.kt
+++ b/cocache-spring-cache/src/test/kotlin/me/ahoo/cache/spring/cache/CoSpringCacheTest.kt
@@ -27,7 +27,9 @@ import me.ahoo.cache.join.SimpleJoinCache
 import me.ahoo.cache.join.proxy.DefaultJoinCacheProxyFactory
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.util.concurrent.CompletableFuture
+import org.springframework.cache.Cache as SpringCache
 
 class CoSpringCacheTest {
     @Suppress("UNCHECKED_CAST")
@@ -64,6 +66,46 @@ class CoSpringCacheTest {
     fun put() {
         coSpringCache.put("putTest", "test")
         coSpringCache.get("putTest")!!.get().assert().isEqualTo("test")
+    }
+
+    @Test
+    fun getWhenMissingGuardReturnsMiss() {
+        coSpringCache.delegate.setCache("missing", DefaultCacheValue.missingGuard())
+
+        coSpringCache.get("missing").assert().isNull()
+    }
+
+    @Test
+    fun getWithLoaderKeepsCachedNull() {
+        var loadCount = 0
+        coSpringCache.put("cachedNull", null)
+
+        val actual = coSpringCache.get("cachedNull") {
+            loadCount++
+            "loaded"
+        }
+
+        actual.assert().isNull()
+        loadCount.assert().isZero()
+    }
+
+    @Test
+    fun getWithTypeMismatchThrowsIllegalStateException() {
+        coSpringCache.put("typed", "value")
+
+        assertThrows<IllegalStateException> {
+            val actual: Int? = coSpringCache.get("typed", Int::class.javaObjectType)
+            actual.assert().isNull()
+        }
+    }
+
+    @Test
+    fun getWithLoaderWrapsException() {
+        assertThrows<SpringCache.ValueRetrievalException> {
+            coSpringCache.get("loaderException") {
+                throw IllegalStateException("boom")
+            }
+        }
     }
 
     @Test

--- a/cocache-spring-cache/src/test/kotlin/me/ahoo/cache/spring/cache/CoSpringCacheTest.kt
+++ b/cocache-spring-cache/src/test/kotlin/me/ahoo/cache/spring/cache/CoSpringCacheTest.kt
@@ -16,8 +16,10 @@ package me.ahoo.cache.spring.cache
 import io.mockk.every
 import io.mockk.mockk
 import me.ahoo.cache.CacheFactory
+import me.ahoo.cache.ComputedTtlAt
 import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.api.Cache
+import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.api.join.JoinValue
 import me.ahoo.cache.client.MapClientSideCache
 import me.ahoo.cache.consistency.CoherentCache
@@ -76,6 +78,29 @@ class CoSpringCacheTest {
     }
 
     @Test
+    fun getWhenExpiredEvictsDelegate() {
+        val expiredCache = RawSpringCache(DefaultCacheValue("expired", ComputedTtlAt.at(-5)))
+        val expiredSpringCache = CoSpringCache("expired", expiredCache)
+
+        expiredSpringCache.get("expired").assert().isNull()
+        expiredCache.evicted.assert().isTrue()
+    }
+
+    @Test
+    fun getWithMatchingTypeReturnsValue() {
+        coSpringCache.put("typedString", "value")
+
+        coSpringCache.get("typedString", String::class.java).assert().isEqualTo("value")
+    }
+
+    @Test
+    fun getWithNullTypeReturnsValue() {
+        coSpringCache.put("typedAny", "value")
+
+        coSpringCache.get<Any>("typedAny", null).assert().isEqualTo("value")
+    }
+
+    @Test
     fun getWithLoaderKeepsCachedNull() {
         var loadCount = 0
         coSpringCache.put("cachedNull", null)
@@ -131,6 +156,11 @@ class CoSpringCacheTest {
         }
         val coSpringCache = CoSpringCache("test", coherentCache)
         coSpringCache.clear()
+    }
+
+    @Test
+    fun clearPlainDelegateCompletes() {
+        CoSpringCache("plain", RawSpringCache()).clear()
     }
 
     @Test
@@ -197,11 +227,44 @@ class CoSpringCacheTest {
     }
 
     @Test
+    fun retrieveWhenMissingReturnsNull() {
+        coSpringCache.retrieve("retrieveMissing").assert().isNull()
+    }
+
+    @Test
     fun testRetrieve() {
         coSpringCache.put("testRetrieve", "test")
         coSpringCache.retrieve("testRetrieveNotFound", {
             CompletableFuture.completedFuture("test")
         }).get().assert().isEqualTo("test")
+    }
+
+    @Test
+    fun retrieveWithLoaderKeepsCachedValue() {
+        var loadCount = 0
+        coSpringCache.put("asyncCached", "cached")
+
+        val actual = coSpringCache.retrieve("asyncCached") {
+            loadCount++
+            CompletableFuture.completedFuture("loaded")
+        }
+
+        actual.get().assert().isEqualTo("cached")
+        loadCount.assert().isZero()
+    }
+
+    @Test
+    fun retrieveWithLoaderKeepsCachedNull() {
+        var loadCount = 0
+        coSpringCache.put("asyncCachedNull", null)
+
+        val actual = coSpringCache.retrieve("asyncCachedNull") {
+            loadCount++
+            CompletableFuture.completedFuture("loaded")
+        }
+
+        actual.get().assert().isNull()
+        loadCount.assert().isZero()
     }
 
     @Test
@@ -212,6 +275,46 @@ class CoSpringCacheTest {
     @Test
     fun getDelegate() {
         coSpringCache.delegate.assert().isNotNull
+    }
+}
+
+private class RawSpringCache(
+    private var cacheValue: CacheValue<Any?>? = null
+) : Cache<Any, Any?> {
+    var evicted: Boolean = false
+        private set
+
+    override fun getCache(key: Any): CacheValue<Any?>? {
+        return cacheValue
+    }
+
+    override fun get(key: Any): Any? {
+        return cacheValue?.takeUnless {
+            it.isMissingGuard || it.isExpired
+        }?.value
+    }
+
+    override fun getTtlAt(key: Any): Long? {
+        return cacheValue?.takeUnless {
+            it.isMissingGuard
+        }?.ttlAt
+    }
+
+    override fun set(key: Any, ttlAt: Long, value: Any?) {
+        cacheValue = DefaultCacheValue(value, ttlAt)
+    }
+
+    override fun set(key: Any, value: Any?) {
+        cacheValue = DefaultCacheValue.forever(value)
+    }
+
+    override fun setCache(key: Any, value: CacheValue<Any?>) {
+        cacheValue = value
+    }
+
+    override fun evict(key: Any) {
+        evicted = true
+        cacheValue = null
     }
 }
 

--- a/cocache-spring-cache/src/test/kotlin/me/ahoo/cache/spring/cache/CoSpringCacheTest.kt
+++ b/cocache-spring-cache/src/test/kotlin/me/ahoo/cache/spring/cache/CoSpringCacheTest.kt
@@ -31,6 +31,8 @@ import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import org.springframework.cache.Cache as SpringCache
 
 class CoSpringCacheTest {
@@ -223,12 +225,52 @@ class CoSpringCacheTest {
     @Test
     fun retrieve() {
         coSpringCache.put("retrieveTest", "test")
-        coSpringCache.retrieve("retrieveTest")!!.get().assert().isEqualTo("test")
+        val valueWrapper = coSpringCache.retrieve("retrieveTest")!!.get()
+        valueWrapper.assert().isInstanceOf(SpringCache.ValueWrapper::class.java)
+        (valueWrapper as SpringCache.ValueWrapper).get().assert().isEqualTo("test")
     }
 
     @Test
     fun retrieveWhenMissingReturnsNull() {
-        coSpringCache.retrieve("retrieveMissing").assert().isNull()
+        coSpringCache.retrieve("retrieveMissing")!!.get().assert().isNull()
+    }
+
+    @Test
+    fun retrieveDoesNotReadDelegateOnCallerThread() {
+        val callerThread = Thread.currentThread()
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        var lookupThread: Thread? = null
+        val cache = object : RawSpringCache(DefaultCacheValue.forever("cached")) {
+            override fun getCache(key: Any): CacheValue<Any?>? {
+                lookupThread = Thread.currentThread()
+                started.countDown()
+                release.await(5, TimeUnit.SECONDS)
+                return super.getCache(key)
+            }
+        }
+        val coSpringCache = CoSpringCache("async", cache)
+        val future = coSpringCache.retrieve("asyncLookup")!!
+
+        started.await(5, TimeUnit.SECONDS).assert().isTrue()
+        try {
+            (lookupThread == callerThread).assert().isFalse()
+        } finally {
+            release.countDown()
+        }
+        val valueWrapper = future.get()
+        valueWrapper.assert().isInstanceOf(SpringCache.ValueWrapper::class.java)
+        (valueWrapper as SpringCache.ValueWrapper).get().assert().isEqualTo("cached")
+    }
+
+    @Test
+    fun retrieveReturnsValueWrapperForCachedNull() {
+        coSpringCache.put("retrieveCachedNull", null)
+
+        val valueWrapper = coSpringCache.retrieve("retrieveCachedNull")!!.get()
+
+        valueWrapper.assert().isInstanceOf(SpringCache.ValueWrapper::class.java)
+        (valueWrapper as SpringCache.ValueWrapper).get().assert().isNull()
     }
 
     @Test
@@ -268,6 +310,17 @@ class CoSpringCacheTest {
     }
 
     @Test
+    fun retrieveWithLoaderReturnsFailedFutureWhenLoaderThrows() {
+        val actual = coSpringCache.retrieve<String>("asyncLoaderException") {
+            throw IllegalStateException("boom")
+        }
+
+        assertThrows<java.util.concurrent.ExecutionException> {
+            actual.get()
+        }.cause.assert().isInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Test
     fun getCacheName() {
         coSpringCache.cacheName.assert().isEqualTo("test")
     }
@@ -278,13 +331,13 @@ class CoSpringCacheTest {
     }
 }
 
-private class RawSpringCache(
+private open class RawSpringCache(
     private var cacheValue: CacheValue<Any?>? = null
 ) : Cache<Any, Any?> {
     var evicted: Boolean = false
         private set
 
-    override fun getCache(key: Any): CacheValue<Any?>? {
+    open override fun getCache(key: Any): CacheValue<Any?>? {
         return cacheValue
     }
 

--- a/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/RedisDistributedCache.kt
+++ b/cocache-spring-redis/src/main/kotlin/me/ahoo/cache/spring/redis/RedisDistributedCache.kt
@@ -50,6 +50,7 @@ class RedisDistributedCache<V>(
 
     override fun setCache(key: String, value: CacheValue<V>) {
         if (value.isExpired) {
+            evict(key)
             return
         }
         codecExecutor.executeAndEncode(key, value)

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/CacheSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/CacheSpec.kt
@@ -48,6 +48,19 @@ abstract class CacheSpec<K, V> {
     }
 
     @Test
+    fun setExpiredCacheValueEvictsExistingValue() {
+        val (key, value) = createCacheEntry()
+        cache[key] = value
+        cache[key].assert().isEqualTo(value)
+
+        val expiredValue = DefaultCacheValue(createCacheEntry().second, ComputedTtlAt.at(-5))
+        cache.setCache(key, expiredValue)
+
+        cache[key].assert().isNull()
+        cache.getTtlAt(key).assert().isNull()
+    }
+
+    @Test
     fun set() {
         val (key, value) = createCacheEntry()
         cache[key].assert().isNull()

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/DefaultCoherentCacheSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/DefaultCoherentCacheSpec.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.cache.test
 
+import me.ahoo.cache.ComputedTtlAt
 import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.api.Cache
 import me.ahoo.cache.api.CacheValue
@@ -94,6 +95,22 @@ abstract class DefaultCoherentCacheSpec<K, V> : CacheSpec<K, V>() {
         CACHE_SOURCE_VALUE.set(cacheValue)
         coherentCache[key].assert().isEqualTo(value)
         CACHE_SOURCE_VALUE.remove()
+    }
+
+    @Test
+    fun getExpiredValueFromCacheSourceDoesNotPopulateCaches() {
+        val (key, value) = createCacheEntry()
+        val cacheValue = DefaultCacheValue(value, ComputedTtlAt.at(-5))
+        CACHE_SOURCE_VALUE.set(cacheValue)
+        val cacheKey = keyConverter.toStringKey(key)
+
+        try {
+            coherentCache.getCache(key)!!.isExpired.assert().isTrue()
+            clientSideCache.getCache(cacheKey).assert().isNull()
+            distributedCache.getCache(cacheKey).assert().isNull()
+        } finally {
+            CACHE_SOURCE_VALUE.remove()
+        }
     }
 
     @Test

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/MultipleInstanceSyncSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/MultipleInstanceSyncSpec.kt
@@ -131,7 +131,7 @@ abstract class MultipleInstanceSyncSpec<K, V> {
 
         currentCache.evict(key)
         currentCache[key].assert().isNull()
-        latch2.await(1, TimeUnit.SECONDS).assert().isTrue()
+        latch3.await(1, TimeUnit.SECONDS).assert().isTrue()
         LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(100))
         otherCache.clientSideCache[cacheKey].assert().isNull()
         otherCache[key].assert().isNull()


### PR DESCRIPTION
## Summary
- Fix cache contract edge cases so expired `CacheValue` writes evict stale entries instead of preserving old values.
- Normalize join-cache missing/expired second values and preserve bounded missing-guard TTLs.
- Align the Spring Cache bridge and Boot auto-configuration with Spring contracts and user-defined bean overrides.
- Add a release verification gate before package publishing.

## Changes
- Core cache behavior now treats expired writes as eviction across client-side, mock distributed, Redis distributed, and coherent cache implementations.
- Join cache reads filter missing/expired second-cache values and keep missing-guard TTL metadata when writing through the join cache.
- Spring Cache integration now hides CoCache missing guards, respects cached `null`, checks requested value types, and wraps synchronous loader failures as `Cache.ValueRetrievalException`.
- Boot auto-configuration now backs off when applications provide their own `CacheManager` or `ClientIdGenerator`.
- Shared TCK and module tests cover expired overwrite, join-cache missing behavior, Spring Cache contract edges, and auto-configuration override paths.
- Release publishing now runs `./gradlew clean check` with Redis before GitHub Packages or Sonatype publishing jobs.

## Testing
- `./gradlew check`
- `git diff --cached --check`
- Parsed `.github/workflows/package-deploy.yml` with Ruby YAML loader.

## Risk & Compatibility
- Behavior change: writing an already-expired `CacheValue` now evicts an existing value instead of leaving stale data in place.
- Behavior change: Spring Cache callers no longer see CoCache missing guards as cache hits, and cached `null` now behaves as a hit for loader methods.
- Behavior change: `get(key, type)` now raises `IllegalStateException` for type mismatches instead of surfacing a cast failure later.
- Behavior change: Boot auto-configuration now backs off from user-provided `CacheManager` and `ClientIdGenerator` beans.
- No public API signatures, package names, or dependency coordinates were changed.

## Review Notes
- Review the cache semantics around expired writes and Spring Cache cached-null behavior closely because they intentionally change observable behavior.
