### PR TITLE
fix(cache): expire values at ttl boundary

### DIFF
--- a/cocache-core/src/main/kotlin/me/ahoo/cache/ComputedTtlAt.kt
+++ b/cocache-core/src/main/kotlin/me/ahoo/cache/ComputedTtlAt.kt
@@ -25,13 +25,13 @@ interface ComputedTtlAt : TtlAt {
         get() = if (isForever) {
             false
         } else {
-            CacheSecondClock.INSTANCE.currentTime() > ttlAt
+            CacheSecondClock.INSTANCE.currentTime() >= ttlAt
         }
 
     override val expiredDuration: Duration
         get() {
             val currentTime = CacheSecondClock.INSTANCE.currentTime()
-            return if (currentTime > ttlAt) {
+            return if (currentTime >= ttlAt) {
                 Duration.ZERO
             } else {
                 Duration.ofSeconds(ttlAt - currentTime)

--- a/cocache-core/src/test/kotlin/me/ahoo/cache/TtlTest.kt
+++ b/cocache-core/src/test/kotlin/me/ahoo/cache/TtlTest.kt
@@ -16,6 +16,7 @@ package me.ahoo.cache
 import me.ahoo.cache.util.CacheSecondClock
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
+import java.time.Duration
 
 class TtlTest {
     @Test
@@ -28,6 +29,15 @@ class TtlTest {
     fun at() {
         val ttlAt = ComputedTtlAt.at(10)
         ttlAt.assert().isGreaterThan(CacheSecondClock.INSTANCE.currentTime())
+    }
+
+    @Test
+    fun expiresAtCurrentSecondIsExpired() {
+        val ttlAt = CacheSecondClock.INSTANCE.currentTime()
+        val cacheValue = DefaultCacheValue("value", ttlAt)
+
+        cacheValue.isExpired.assert().isTrue()
+        cacheValue.expiredDuration.assert().isEqualTo(Duration.ZERO)
     }
 
     @Test

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/CacheSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/CacheSpec.kt
@@ -17,6 +17,7 @@ import me.ahoo.cache.ComputedTtlAt
 import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.MissingGuard
 import me.ahoo.cache.api.Cache
+import me.ahoo.cache.util.CacheSecondClock
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -55,6 +56,19 @@ abstract class CacheSpec<K, V> {
 
         val expiredValue = DefaultCacheValue(createCacheEntry().second, ComputedTtlAt.at(-5))
         cache.setCache(key, expiredValue)
+
+        cache[key].assert().isNull()
+        cache.getTtlAt(key).assert().isNull()
+    }
+
+    @Test
+    fun setExpiresAtCurrentSecondEvictsExistingValue() {
+        val (key, value) = createCacheEntry()
+        cache[key] = value
+        cache[key].assert().isEqualTo(value)
+
+        val expiresNow = CacheSecondClock.INSTANCE.currentTime()
+        cache[key, expiresNow] = value
 
         cache[key].assert().isNull()
         cache.getTtlAt(key).assert().isNull()


### PR DESCRIPTION
## Summary
- Treat cache values whose `ttlAt` equals the current cache second as expired.
- Align in-memory expiration semantics with Redis zero-TTL behavior.
- Extend shared cache contract tests so implementations evict writes that expire at the current second.

## Changes
- Cache core: update `ComputedTtlAt` expiration and `expiredDuration` boundary checks to use `currentTime >= ttlAt`.
- Tests: add direct TTL boundary coverage and shared `CacheSpec` regression coverage.

## Testing
- `./gradlew check`

## Risk & Compatibility
- Low risk; no broad breaking changes identified from the diff.
- Exact-boundary cache entries now expire immediately instead of remaining visible in memory until the next cache second.

## Review Notes
- Review the expire-at boundary semantics and shared cache contract coverage.