### PR TITLE
fix(deps): update cosid to 3.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # libraries
 spring-boot = "4.1.0"
-cosid = "3.1.0"
+cosid = "3.2.0"
 guava = "33.6.0-jre"
 kotlin-logging = "8.0.4"
 springdoc = "3.0.3"

--- a/wiki/building/index.md
+++ b/wiki/building/index.md
@@ -119,7 +119,7 @@ api(platform(dependenciesProject))
 |------------|---------|--------|
 | Kotlin | 2.3.20 | [`libs.versions.toml:14`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle/libs.versions.toml#L14) |
 | Spring Boot | 4.0.5 | [`libs.versions.toml:3`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle/libs.versions.toml#L3) |
-| CoSid | 3.0.5 | [`libs.versions.toml:4`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle/libs.versions.toml#L4) |
+| CoSid | 3.2.0 | [`libs.versions.toml:4`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle/libs.versions.toml#L4) |
 | Detekt | 1.23.8 | [`libs.versions.toml:13`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle/libs.versions.toml#L13) |
 | Dokka | 2.2.0 | [`libs.versions.toml:14`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle/libs.versions.toml#L14) |
 | JUnit | 6.0.3 | [`libs.versions.toml:9`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle/libs.versions.toml#L9) |

--- a/wiki/guide/changelog.md
+++ b/wiki/guide/changelog.md
@@ -14,7 +14,7 @@ description: Release history and notable changes for CoCache.
 | Dependency | Version |
 |------------|---------|
 | Spring Boot | 4.0.5 |
-| CosId | 3.0.5 |
+| CosId | 3.2.0 |
 | Guava | 33.5.0-jre |
 | Kotlin | 2.3.20 |
 | JUnit | 6.0.3 |

--- a/wiki/zh/building/index.md
+++ b/wiki/zh/building/index.md
@@ -119,7 +119,7 @@ api(platform(dependenciesProject))
 |------|------|------|
 | Kotlin | 2.3.20 | [`libs.versions.toml:14`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle/libs.versions.toml#L14) |
 | Spring Boot | 4.0.5 | [`libs.versions.toml:3`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle/libs.versions.toml#L3) |
-| CoSid | 3.0.5 | [`libs.versions.toml:4`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle/libs.versions.toml#L4) |
+| CoSid | 3.2.0 | [`libs.versions.toml:4`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle/libs.versions.toml#L4) |
 | Detekt | 1.23.8 | [`libs.versions.toml:13`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle/libs.versions.toml#L13) |
 | Dokka | 2.2.0 | [`libs.versions.toml:14`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle/libs.versions.toml#L14) |
 | JUnit | 6.0.3 | [`libs.versions.toml:9`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle/libs.versions.toml#L9) |

--- a/wiki/zh/guide/changelog.md
+++ b/wiki/zh/guide/changelog.md
@@ -14,7 +14,7 @@ description: CoCache 版本发布历史和重要变更。
 | 依赖 | 版本 |
 |------|------|
 | Spring Boot | 4.0.5 |
-| CosId | 3.0.5 |
+| CosId | 3.2.0 |
 | Guava | 33.5.0-jre |
 | Kotlin | 2.3.20 |
 | JUnit | 6.0.3 |


### PR DESCRIPTION
## Summary

Sync from `main` and bump [CosId](https://github.com/Ahoo-Wang/CosId) from `3.1.0` → `3.2.0` (released 2026-07-07).

## Changes
- `gradle/libs.versions.toml` — `cosid = 3.2.0`
- Synced CosId version references in wiki docs (`changelog.md`, `building/index.md`, EN + ZH)

## Verification
- ✅ `./gradlew build -x test`
- ✅ Unit tests: `:cocache-core:test`, `:cocache-spring:test`, `:cocache-spring-cache:test`, `:cocache-spring-boot-starter:test`
- ⏭️ Skipped `:cocache-spring-redis:test` (requires Redis)

## References
- [CosId v3.2.0 release](https://github.com/Ahoo-Wang/CosId/releases/tag/v3.2.0)