### PR TITLE
docs(wiki): sync to 4.3.0 with degradation, sentinel and lifecycle guides

### DIFF
--- a/wiki/.vitepress/config/en.ts
+++ b/wiki/.vitepress/config/en.ts
@@ -13,7 +13,7 @@ export const en: DefaultTheme.Config = {
       { text: 'Modules', link: '/modules/' },
       { text: 'Onboarding', link: '/onboarding/' },
       {
-        text: 'v4.2',
+        text: 'v4.3',
         items: [
           { text: 'Changelog', link: '/guide/changelog' },
           { text: 'Contributing', link: '/guide/contributing' },

--- a/wiki/.vitepress/config/zh.ts
+++ b/wiki/.vitepress/config/zh.ts
@@ -13,7 +13,7 @@ export const zh: DefaultTheme.Config = {
       { text: '模块', link: '/zh/modules/' },
       { text: '入门指南', link: '/zh/onboarding/' },
       {
-        text: 'v4.2',
+        text: 'v4.3',
         items: [
           { text: '更新日志', link: '/zh/guide/changelog' },
           { text: '贡献指南', link: '/zh/guide/contributing' },

--- a/wiki/architecture/cache-layers.md
+++ b/wiki/architecture/cache-layers.md
@@ -173,6 +173,16 @@ autonumber
 | `FOREVER` | `-1` | Key exists but has no expiration |
 | `NOT_EXIST` | `-2` | Key does not exist in Redis |
 
+### Failure Degradation & Self-Healing (v4.3.0)
+
+Since v4.3.0, `RedisDistributedCache` absorbs Redis failures instead of propagating them:
+
+- **Read failures** (`DataAccessException`) degrade to a cache miss — `getCache` returns `null`, the coherent cache falls back to the source, and business calls continue to work through Redis outages.
+- **Write / evict failures** are logged at `WARN` and swallowed.
+- Set `cocache.redis.strict-failure=true` to restore strict exception propagation (see [Configuration](/guide/configuration#redis-failure-degradation-v4-3-0)).
+
+Additionally, the codec layer **self-heals corrupted payloads**: if a stored value cannot be decoded (external corruption, incompatible schema), the key is deleted and the read is treated as a cache miss so the next load repopulates a valid value — a broken key no longer throws on every read until TTL expiry.
+
 ## L0 -- CacheSource (Data Source)
 
 The L0 layer represents the authoritative data source (typically a database). It is the last resort when both L2 and L1 miss. The [`CacheSource<K, V>`](https://github.com/Ahoo-Wang/CoCache/blob/main/cocache-api/src/main/kotlin/me/ahoo/cache/api/source/CacheSource.kt#L24) interface defines a single method:

--- a/wiki/architecture/coherence.md
+++ b/wiki/architecture/coherence.md
@@ -237,6 +237,10 @@ flowchart LR
 
 ```
 
+### Close Lifecycle (v4.3.0)
+
+Since v4.3.0, the lifecycle is closed-loop: `CoherentCache` extends `AutoCloseable` and `DefaultCoherentCache.close()` performs the `unregister` step idempotently (guarded by an atomic CAS — repeated calls are no-ops), then closes the distributed cache. In Spring applications, `CacheProxyFactoryBean`/`JoinCacheProxyFactoryBean` implement `DisposableBean`, so caches are unregistered and closed automatically at container shutdown. Manual (non-Spring) users should call `close()` when discarding a cache — previously, subscribers were registered on construction but never unregistered, leaking subscriptions for non-singleton cache lifecycles.
+
 ## Comparison of EventBus Implementations
 
 | Feature | GuavaCacheEvictedEventBus | RedisCacheEvictedEventBus | NoOpCacheEvictedEventBus |

--- a/wiki/building/publishing.md
+++ b/wiki/building/publishing.md
@@ -117,7 +117,7 @@ The POM properties are sourced from [`gradle.properties`](https://github.com/Aho
 | Property | Value | Source |
 |----------|-------|--------|
 | `group` | `me.ahoo.cocache` | [`gradle.properties:14`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L14) |
-| `version` | `4.2.0` | [`gradle.properties:15`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L15) |
+| `version` | `4.3.0` | [`gradle.properties:15`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L15) |
 | `description` | `Level 2 Distributed Coherence Cache Framework` | [`gradle.properties:17`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L17) |
 | `website` | `https://github.com/Ahoo-Wang/CoCache` | [`gradle.properties:18`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L18) |
 | `license_name` | `The Apache Software License, Version 2.0` | [`gradle.properties:22`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L22) |
@@ -128,7 +128,7 @@ The project version is defined centrally in [`gradle.properties`](https://github
 
 ```properties
 # [gradle.properties:15](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L15)
-version=4.2.0
+version=4.3.0
 ```
 
 All published artifacts share this version. To prepare a release:

--- a/wiki/guide/changelog.md
+++ b/wiki/guide/changelog.md
@@ -5,7 +5,56 @@ description: Release history and notable changes for CoCache.
 
 # Changelog
 
-## v4.2.0 (Current)
+## v4.3.0 (Current)
+
+**Module Group:** `me.ahoo.cocache`
+
+### Highlights
+
+- **Cache Breakdown Protection Hardened** — Replaced the per-key lock map (which had a lock-object recycling race allowing duplicate source loads) with Guava `Striped` locks in `DefaultCoherentCache` (#519).
+- **Clock Thread Startup Race Fixed** — `CacheSecondClock` timer thread startup no longer races with field initialization; eliminates the "frozen clock → caches never expire" failure mode (#519).
+- **Stale Write-Back Race Fixed** — A per-key invalidation generation counter makes in-flight loads detect eviction events that arrive during loading: stale results are discarded (or compensating-evicted) instead of being pinned into both cache tiers until TTL (#519).
+- **Lifecycle Management** — `CoherentCache` now extends `AutoCloseable` with an idempotent `close()` (unregister from event bus + close distributed cache); Spring destroys caches automatically at shutdown (#519).
+- **Corrupted Payload Self-Healing** — Undecodable Redis values are deleted and treated as a cache miss (source reload) instead of throwing on every read (#520).
+- **Null Value Normalization** — `null` values are consistently written as negative-cache sentinels across all codecs (previously: empty-string corruption, NPEs, or codec-dependent semantics) (#520).
+- **Redis Failure Degradation** — By default, Redis read failures now degrade to cache-miss semantics (source reload, business calls unaffected) and write/evict failures only log a warning. Set `cocache.redis.strict-failure=true` to restore the strict throwing behavior (#520).
+- **Atomic Hash/Set Writes** — Structural codec writes use single-key Lua scripts (`DEL` + `HSET`/`SADD` + `EXPIRE`), eliminating concurrent-write field-union corruption. Empty Map/Set writes now silently evict the key instead of throwing (#520).
+- **Configurable Missing-Guard Sentinel** — New property `cocache.redis.missing-guard-sentinel` mitigates collisions between business data and the `"_nil_"` sentinel (#520).
+
+### Breaking Changes & Behavior Notes
+
+- **API removal (the only breaking change)**: `AbstractCodecExecutor.setPipelined`/`serialize` members were removed — affects only third-party codecs directly extending this abstract class.
+- `CodecExecutor.executeAndDecode` return type is now nullable (`CacheValue<V>?`) — covariant-compatible for implementers; direct callers must handle `null` on recompile.
+- Redis failures degrade by default (previously threw); JSON codec `null` values become negative-cache sentinels instead of `"null"`-literal round-trips.
+- Spring containers now auto-close caches at shutdown; `FactoryBean.getObject()` returns a memoized instance (eliminates duplicate event-bus subscriptions).
+- `strict-failure` / `missing-guard-sentinel` apply only to auto-configured (fallback-created) caches; custom `DistributedCache` beans are unaffected.
+- Wire formats (storage structure, eviction messages) are unchanged — rolling upgrades are fully compatible.
+
+### Dependencies
+
+| Dependency | Version |
+|------------|---------|
+| Spring Boot | 4.1.0 |
+| CosId | 3.2.0 |
+| Guava | 33.6.0-jre |
+| Kotlin | 2.4.10 |
+| JUnit | 6.1.3 |
+
+### Gradle Setup
+
+```kotlin
+implementation("me.ahoo.cocache:cocache-spring-boot-starter:4.3.0")
+```
+
+```xml
+<dependency>
+  <groupId>me.ahoo.cocache</groupId>
+  <artifactId>cocache-spring-boot-starter</artifactId>
+  <version>4.3.0</version>
+</dependency>
+```
+
+## v4.2.0
 
 **Module Group:** `me.ahoo.cocache`
 

--- a/wiki/guide/configuration.md
+++ b/wiki/guide/configuration.md
@@ -106,16 +106,47 @@ Source: [cocache-example/.../cache/UserExtendInfoJoinCache.kt](https://github.co
 | Property | Type | Default | Description | Source |
 |----------|------|---------|-------------|--------|
 | `cocache.enabled` | `Boolean` | `true` | Enables or disables the entire CoCache auto-configuration | [CoCacheProperties.kt](https://github.com/Ahoo-Wang/CoCache/blob/main/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheProperties.kt) |
+| `cocache.redis.strict-failure` | `Boolean` | `false` | Redis failure policy: `false` = degrade (reads fall back to source, writes log warnings); `true` = rethrow `DataAccessException` (pre-4.3.0 behavior) | [CoCacheProperties.kt](https://github.com/Ahoo-Wang/CoCache/blob/main/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheProperties.kt) |
+| `cocache.redis.missing-guard-sentinel` | `String` | `"_nil_"` | Custom missing-guard sentinel value for Redis codecs (see notes below) | [CoCacheProperties.kt](https://github.com/Ahoo-Wang/CoCache/blob/main/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheProperties.kt) |
 
 ```yaml
 # application.yml
 cocache:
   enabled: true
+  redis:
+    strict-failure: false
+    missing-guard-sentinel: "_nil_"
 ```
 
 When `cocache.enabled` is `false`, all CoCache beans are skipped. The conditional is handled by `@ConditionalOnCoCacheEnabled`.
 
 Source: [ConditionalOnCoCacheEnabled.kt](https://github.com/Ahoo-Wang/CoCache/blob/main/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/ConditionalOnCoCacheEnabled.kt)
+
+#### Redis Failure Degradation (v4.3.0)
+
+Since v4.3.0, `RedisDistributedCache` degrades instead of propagating Redis failures to business callers:
+
+- **Read failures** → treated as a cache miss: the coherent cache falls back to the source (database), so business calls are unaffected during Redis outages or master-slave switchovers.
+- **Write / evict failures** → logged at `WARN` and swallowed — a cache write failure never blocks the business write path.
+- The eviction-event publish path (`RedisCacheEvictedEventBus`) degrades the same way (pub/sub is fire-and-forget by nature).
+
+Set `cocache.redis.strict-failure=true` to restore the strict pre-4.3.0 behavior (exceptions propagate). Note that during an outage with degradation enabled, every key not served by the local L2 cache falls back to the source once per client-side TTL window per process — plan source capacity accordingly. These properties apply only to auto-configured (fallback-created) caches; custom `DistributedCache` beans manage their own policy.
+
+#### Missing-Guard Sentinel (v4.3.0)
+
+Redis codecs mark negative-cache entries with the sentinel value `"_nil_"`. If your business data can legitimately equal the sentinel (an exact `"_nil_"` string, a single-element `{"_nil_"}` set, or a single-`"_nil_"`-keyed map written by an external writer), configure a custom sentinel:
+
+```yaml
+cocache:
+  redis:
+    missing-guard-sentinel: "\u0000myapp:nil"
+```
+
+Constraints:
+
+- Custom and default sentinels **do not recognize each other** — switching requires a simultaneous cluster-wide change (during a rolling upgrade, old instances would misread the new sentinel as a real value).
+- The value must not equal any legitimate serialized business value, and must not be blank (binding fails fast).
+- This affects only the Redis at-rest bytes written/read by the codecs; in-process missing-guard checks are unaffected.
 
 ## Auto-Configuration Bean Registry
 

--- a/wiki/guide/index.md
+++ b/wiki/guide/index.md
@@ -5,7 +5,7 @@ description: Level 2 Distributed Coherence Cache Framework for Java/Kotlin - Ove
 
 # CoCache Introduction
 
-**CoCache** is a **Level 2 Distributed Coherence Cache Framework** for Java/Kotlin that provides a two-level caching architecture with event-driven coherence across distributed instances. It is published under the group `me.ahoo.cocache` at version **4.2.0**.
+**CoCache** is a **Level 2 Distributed Coherence Cache Framework** for Java/Kotlin that provides a two-level caching architecture with event-driven coherence across distributed instances. It is published under the group `me.ahoo.cocache` at version **4.3.0**.
 
 CoCache sits between your application and your data source, adding two cache layers -- a local in-memory L2 cache (Guava or Caffeine) and a shared distributed L1 cache (Redis) -- while keeping all instances coherent through an event bus.
 
@@ -219,7 +219,7 @@ autonumber
 | Property | Value | Source |
 |----------|-------|--------|
 | Group | `me.ahoo.cocache` | [gradle.properties:14](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L14) |
-| Version | `4.2.0` | [gradle.properties:15](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L15) |
+| Version | `4.3.0` | [gradle.properties:15](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L15) |
 | License | Apache License 2.0 | [gradle.properties:23](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L23) |
 | JDK | 17+ (via `jvmToolchain`) | [build.gradle.kts](https://github.com/Ahoo-Wang/CoCache/blob/main/build.gradle.kts) |
 | Gradle | 9.6.1 (wrapper) | [gradle/wrapper/gradle-wrapper.properties](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle/wrapper/gradle-wrapper.properties) |

--- a/wiki/guide/quick-start.md
+++ b/wiki/guide/quick-start.md
@@ -20,7 +20,7 @@ This guide walks you through adding CoCache to a Spring Boot application, defini
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("me.ahoo.cocache:cocache-spring-boot-starter:4.2.0")
+    implementation("me.ahoo.cocache:cocache-spring-boot-starter:4.3.0")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 }
 ```
@@ -29,7 +29,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'me.ahoo.cocache:cocache-spring-boot-starter:4.2.0'
+    implementation 'me.ahoo.cocache:cocache-spring-boot-starter:4.3.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 ```
@@ -40,7 +40,7 @@ dependencies {
 <dependency>
     <groupId>me.ahoo.cocache</groupId>
     <artifactId>cocache-spring-boot-starter</artifactId>
-    <version>4.2.0</version>
+    <version>4.3.0</version>
 </dependency>
 <dependency>
     <groupId>org.springframework.boot</groupId>

--- a/wiki/testing/unit-testing.md
+++ b/wiki/testing/unit-testing.md
@@ -14,7 +14,7 @@ Add the `cocache-test` module as a test dependency:
 ```kotlin
 // build.gradle.kts
 dependencies {
-    testImplementation("me.ahoo.cocache:cocache-test:4.2.0")
+    testImplementation("me.ahoo.cocache:cocache-test:4.3.0")
     testImplementation("me.ahoo.test:fluent-assert-core")
     testImplementation("io.mockk:mockk")
 }

--- a/wiki/zh/architecture/cache-layers.md
+++ b/wiki/zh/architecture/cache-layers.md
@@ -173,6 +173,16 @@ autonumber
 | `FOREVER` | `-1` | 键存在但没有过期时间 |
 | `NOT_EXIST` | `-2` | 键在 Redis 中不存在 |
 
+### 故障降级与自愈（v4.3.0）
+
+自 v4.3.0 起，`RedisDistributedCache` 吸收 Redis 故障而非向调用方传播：
+
+- **读失败**（`DataAccessException`）降级为缓存未命中——`getCache` 返回 `null`，一致性缓存回退数据源，Redis 故障期间业务调用持续可用。
+- **写 / evict 失败**记录 `WARN` 后吞掉。
+- 设置 `cocache.redis.strict-failure=true` 可恢复严格异常传播（见[配置参考](/zh/guide/configuration#redis-故障降级-v4-3-0)）。
+
+此外，codec 层对**脏载荷自愈**：存储值无法解码时（外部损坏、schema 不兼容），该 key 被删除且读取按未命中处理，下次回源重建有效值——损坏的 key 不再在 TTL 期内每次读取都抛异常。
+
 ## L0 -- CacheSource（数据源）
 
 L0 层代表权威数据源（通常是数据库）。它是 L2 和 L1 都未命中时的最后兜底。[`CacheSource<K, V>`](https://github.com/Ahoo-Wang/CoCache/blob/main/cocache-api/src/main/kotlin/me/ahoo/cache/api/source/CacheSource.kt#L24) 接口定义了一个方法：

--- a/wiki/zh/architecture/coherence.md
+++ b/wiki/zh/architecture/coherence.md
@@ -237,6 +237,10 @@ flowchart LR
 
 ```
 
+### 关闭生命周期（v4.3.0）
+
+自 v4.3.0 起，生命周期形成闭环：`CoherentCache` 继承 `AutoCloseable`，`DefaultCoherentCache.close()` 幂等地执行注销步骤（原子 CAS 防护——重复调用为无操作），随后关闭分布式缓存。Spring 应用中，`CacheProxyFactoryBean`/`JoinCacheProxyFactoryBean` 实现了 `DisposableBean`，容器关闭时自动注销并关闭缓存。手工（非 Spring）用户应在废弃缓存时调用 `close()`——此前订阅者在构造时注册但永不注销，非单例缓存生命周期会泄漏订阅。
+
 ## EventBus 实现对比
 
 | 特性 | GuavaCacheEvictedEventBus | RedisCacheEvictedEventBus | NoOpCacheEvictedEventBus |

--- a/wiki/zh/building/publishing.md
+++ b/wiki/zh/building/publishing.md
@@ -117,7 +117,7 @@ POM 属性来源于 [`gradle.properties`](https://github.com/Ahoo-Wang/CoCache/b
 | 属性 | 值 | 来源 |
 |------|-----|------|
 | `group` | `me.ahoo.cocache` | [`gradle.properties:14`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L14) |
-| `version` | `4.2.0` | [`gradle.properties:15`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L15) |
+| `version` | `4.3.0` | [`gradle.properties:15`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L15) |
 | `description` | `Level 2 Distributed Coherence Cache Framework` | [`gradle.properties:17`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L17) |
 | `website` | `https://github.com/Ahoo-Wang/CoCache` | [`gradle.properties:18`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L18) |
 | `license_name` | `The Apache Software License, Version 2.0` | [`gradle.properties:22`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L22) |
@@ -128,7 +128,7 @@ POM 属性来源于 [`gradle.properties`](https://github.com/Ahoo-Wang/CoCache/b
 
 ```properties
 # [gradle.properties:15](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L15)
-version=4.2.0
+version=4.3.0
 ```
 
 所有已发布构件共享此版本。准备发布时：

--- a/wiki/zh/guide/changelog.md
+++ b/wiki/zh/guide/changelog.md
@@ -5,7 +5,56 @@ description: CoCache 版本发布历史和重要变更。
 
 # 更新日志
 
-## v4.2.0（当前版本）
+## v4.3.0（当前版本）
+
+**模块组：** `me.ahoo.cocache`
+
+### 亮点
+
+- **击穿防护加固** —— `DefaultCoherentCache` 的 per-key 锁映射（存在锁对象回收竞态，可能导致并发重复回源）替换为 Guava `Striped` 锁（#519）。
+- **时钟线程启动竞态修复** —— `CacheSecondClock` 计时线程启动不再与字段初始化竞态；杜绝"时钟冻结 → 缓存永不过期"的故障模式（#519）。
+- **旧值回填竞态修复** —— 引入 per-key 失效代际计数器，在途回源可检测加载期间到达的失效事件：过期结果被丢弃（或补偿淘汰），不再钉死在两级缓存直至 TTL（#519）。
+- **生命周期管理** —— `CoherentCache` 新增幂等 `close()`（注销事件订阅 + 关闭分布式缓存）；Spring 容器关闭时自动销毁缓存（#519）。
+- **脏载荷自愈** —— 无法解码的 Redis 值被删除并按缓存未命中处理（回源重建），不再每次读取都抛异常（#520）。
+- **null 值归一化** —— null 值在所有 codec 下一致写入为负缓存哨兵（此前：空串损坏、NPE 或 codec 各异的语义）（#520）。
+- **Redis 故障降级** —— 默认情况下，Redis 读失败降级为缓存未命中语义（回源，业务无感），写/evict 失败仅记录告警。设置 `cocache.redis.strict-failure=true` 可恢复严格抛出行为（#520）。
+- **Hash/Set 原子写入** —— 结构型 codec 写入使用单 key Lua 脚本（`DEL` + `HSET`/`SADD` + `EXPIRE`），消除并发写"字段混合"脏值。空 Map/Set 写入改为静默淘汰而非抛异常（#520）。
+- **哨兵值可配置** —— 新属性 `cocache.redis.missing-guard-sentinel` 缓解业务数据与 `"_nil_"` 哨兵的碰撞（#520）。
+
+### 破坏性变更与行为说明
+
+- **API 移除（唯一破坏性变更）**：`AbstractCodecExecutor.setPipelined`/`serialize` 成员被移除——仅影响直接继承该抽象类的第三方 codec。
+- `CodecExecutor.executeAndDecode` 返回类型可空化（`CacheValue<V>?`）——对实现者协变兼容；直接调用方重编译时需处理 `null`。
+- Redis 故障默认降级（此前为抛异常）；JSON codec 的 null 值从 `"null"` 字面量往返变为负缓存哨兵。
+- Spring 容器关闭时自动 close 缓存；`FactoryBean.getObject()` 返回记忆化实例（消除重复事件订阅）。
+- `strict-failure` / `missing-guard-sentinel` 仅作用于自动装配（fallback）创建的缓存；自定义 `DistributedCache` Bean 不受影响。
+- 线上格式（存储结构、失效消息）零变更——滚动升级完全兼容。
+
+### 依赖版本
+
+| 依赖 | 版本 |
+|------------|---------|
+| Spring Boot | 4.1.0 |
+| CosId | 3.2.0 |
+| Guava | 33.6.0-jre |
+| Kotlin | 2.4.10 |
+| JUnit | 6.1.3 |
+
+### Gradle 配置
+
+```kotlin
+implementation("me.ahoo.cocache:cocache-spring-boot-starter:4.3.0")
+```
+
+```xml
+<dependency>
+  <groupId>me.ahoo.cocache</groupId>
+  <artifactId>cocache-spring-boot-starter</artifactId>
+  <version>4.3.0</version>
+</dependency>
+```
+
+## v4.2.0
 
 **模块组：** `me.ahoo.cocache`
 

--- a/wiki/zh/guide/configuration.md
+++ b/wiki/zh/guide/configuration.md
@@ -106,16 +106,47 @@ interface UserExtendInfoJoinCache : JoinCache<String, UserExtendInfo, String, Us
 | 属性 | 类型 | 默认值 | 说明 | 源码 |
 |------|------|--------|------|------|
 | `cocache.enabled` | `Boolean` | `true` | 启用或禁用整个 CoCache 自动配置 | [CoCacheProperties.kt](https://github.com/Ahoo-Wang/CoCache/blob/main/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheProperties.kt) |
+| `cocache.redis.strict-failure` | `Boolean` | `false` | Redis 故障策略：`false` = 降级（读回源、写仅告警）；`true` = 重抛 `DataAccessException`（4.3.0 之前的行为） | [CoCacheProperties.kt](https://github.com/Ahoo-Wang/CoCache/blob/main/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheProperties.kt) |
+| `cocache.redis.missing-guard-sentinel` | `String` | `"_nil_"` | 自定义 Redis codec 负缓存哨兵值（约束见下文） | [CoCacheProperties.kt](https://github.com/Ahoo-Wang/CoCache/blob/main/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheProperties.kt) |
 
 ```yaml
 # application.yml
 cocache:
   enabled: true
+  redis:
+    strict-failure: false
+    missing-guard-sentinel: "_nil_"
 ```
 
 当 `cocache.enabled` 为 `false` 时，所有 CoCache Bean 都会被跳过。条件化由 `@ConditionalOnCoCacheEnabled` 处理。
 
 源码：[ConditionalOnCoCacheEnabled.kt](https://github.com/Ahoo-Wang/CoCache/blob/main/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/ConditionalOnCoCacheEnabled.kt)
+
+#### Redis 故障降级（v4.3.0）
+
+自 v4.3.0 起，`RedisDistributedCache` 对 Redis 故障降级处理，不再向业务调用方传播异常：
+
+- **读失败** → 按缓存未命中处理：一致性缓存回退到数据源回源，Redis 故障或主从切换期间业务调用不受影响。
+- **写 / evict 失败** → 记录 `WARN` 后吞掉——缓存写入失败不会阻断业务写路径。
+- 失效事件发布路径（`RedisCacheEvictedEventBus`）同样降级（pub/sub 本就是 fire-and-forget）。
+
+设置 `cocache.redis.strict-failure=true` 可恢复 4.3.0 之前的严格行为（异常传播）。注意：降级启用时，故障期间本地 L2 未命中的 key 每进程每客户端 TTL 窗口至多回源一次——请据此规划数据源容量。这两个属性仅作用于自动装配（fallback）创建的缓存；自定义 `DistributedCache` Bean 自行管理其策略。
+
+#### 负缓存哨兵（v4.3.0）
+
+Redis codec 用哨兵值 `"_nil_"` 标记负缓存条目。若业务数据可能合法地等于哨兵（外部写入者写入的精确 `"_nil_"` 字符串、单元素 `{"_nil_"}` 集合或单 `"_nil_"` 键的 Map），可配置自定义哨兵：
+
+```yaml
+cocache:
+  redis:
+    missing-guard-sentinel: "\u0000myapp:nil"
+```
+
+约束：
+
+- 自定义哨兵与默认哨兵**互不识别**——切换需全集群同时变更（滚动升级期间旧实例会把新哨兵误读为真实值）。
+- 取值不得等于任何合法的业务序列化值，且不得为空白（绑定时 fail-fast）。
+- 仅影响 codec 读写的 Redis 静止字节；进程内 missing-guard 判定不受影响。
 
 ## 自动配置 Bean 注册表
 

--- a/wiki/zh/guide/index.md
+++ b/wiki/zh/guide/index.md
@@ -5,7 +5,7 @@ description: 面向 Java/Kotlin 的二级分布式一致性缓存框架 -- 概�
 
 # CoCache 介绍
 
-**CoCache** 是一个面向 Java/Kotlin 的**二级分布式一致性缓存框架**，提供基于事件驱动一致性的两级缓存架构。它以 `me.ahoo.cocache` 为组织标识发布，当前版本为 **4.2.0**。
+**CoCache** 是一个面向 Java/Kotlin 的**二级分布式一致性缓存框架**，提供基于事件驱动一致性的两级缓存架构。它以 `me.ahoo.cocache` 为组织标识发布，当前版本为 **4.3.0**。
 
 CoCache 位于应用与数据源之间，增加两层缓存 -- 本地内存 L2 缓存（Guava 或 Caffeine）和共享的分布式 L1 缓存（Redis） -- 同时通过事件总线保持所有实例间的缓存一致性。
 
@@ -219,7 +219,7 @@ autonumber
 | 属性 | 值 | 源码 |
 |------|-----|------|
 | Group | `me.ahoo.cocache` | [gradle.properties:14](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L14) |
-| Version | `4.2.0` | [gradle.properties:15](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L15) |
+| Version | `4.3.0` | [gradle.properties:15](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L15) |
 | License | Apache License 2.0 | [gradle.properties:23](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L23) |
 | JDK | 17+（通过 `jvmToolchain`） | [build.gradle.kts](https://github.com/Ahoo-Wang/CoCache/blob/main/build.gradle.kts) |
 | Gradle | 9.6.1（wrapper） | [gradle/wrapper/gradle-wrapper.properties](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle/wrapper/gradle-wrapper.properties) |

--- a/wiki/zh/guide/quick-start.md
+++ b/wiki/zh/guide/quick-start.md
@@ -20,7 +20,7 @@ description: 几分钟内开始使用 CoCache -- Gradle/Maven 依赖配置、@En
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("me.ahoo.cocache:cocache-spring-boot-starter:4.2.0")
+    implementation("me.ahoo.cocache:cocache-spring-boot-starter:4.3.0")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 }
 ```
@@ -29,7 +29,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'me.ahoo.cocache:cocache-spring-boot-starter:4.2.0'
+    implementation 'me.ahoo.cocache:cocache-spring-boot-starter:4.3.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 ```
@@ -40,7 +40,7 @@ dependencies {
 <dependency>
     <groupId>me.ahoo.cocache</groupId>
     <artifactId>cocache-spring-boot-starter</artifactId>
-    <version>4.2.0</version>
+    <version>4.3.0</version>
 </dependency>
 <dependency>
     <groupId>org.springframework.boot</groupId>

--- a/wiki/zh/testing/unit-testing.md
+++ b/wiki/zh/testing/unit-testing.md
@@ -14,7 +14,7 @@ CoCache 提供了抽象测试规范类（TCK）来验证缓存行为。本指南
 ```kotlin
 // build.gradle.kts
 dependencies {
-    testImplementation("me.ahoo.cocache:cocache-test:4.2.0")
+    testImplementation("me.ahoo.cocache:cocache-test:4.3.0")
     testImplementation("me.ahoo.test:fluent-assert-core")
     testImplementation("io.mockk:mockk")
 }


### PR DESCRIPTION
## Summary

Wiki 站点同步至 v4.3.0（本次发布的两大专项此前完全未覆盖），并补齐新特性文档：

- **Changelog**：新增 v4.3.0 小节（亮点 / 破坏性变更与行为说明 / 依赖表 / 安装片段，en+zh），v4.2.0 转为历史
- **配置参考**：`cocache.redis.strict-failure`、`cocache.redis.missing-guard-sentinel` 两个新属性（表格 + YAML + 语义详述：降级策略、回源放大权衡、哨兵切换约束，en+zh）
- **架构页**：cache-layers 新增"故障降级与自愈"小节；coherence 新增"关闭生命周期"小节（close() 幂等注销 + Spring 自动销毁，en+zh）
- **版本引用**：20 处当前版本引用 4.2.0 → 4.3.0（quick-start / index / unit-testing / publishing，en+zh）；6 处历史记录按原样保留
- **导航**：版本徽标 v4.2 → v4.3（en+zh）

## 审查结论（本次未改动的部分）

站点结构健康：build 零死链、双语 69 页完全对齐、暗色 Mermaid 与点击缩放已实现、本地搜索双语言配置完整。`llms.txt`/`llms-full.txt` 为生成产物，待内容沉淀后另行再生成。

## Test Plan

- [x] `pnpm build` 通过（渲染 + sitemap，零死链）
- [ ] 预览人工核对双语新增小节