### PR TITLE
fix(test): tolerate one-second ttl drift in redis ttl assertions

### DIFF
--- a/cocache-spring-redis/src/test/kotlin/me/ahoo/cache/spring/redis/RedisDistributedCachingTest.kt
+++ b/cocache-spring-redis/src/test/kotlin/me/ahoo/cache/spring/redis/RedisDistributedCachingTest.kt
@@ -12,11 +12,15 @@
  */
 package me.ahoo.cache.spring.redis
 
+import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.distributed.DistributedCache
 import me.ahoo.cache.spring.redis.codec.StringToStringCodecExecutor
 import me.ahoo.cache.test.DistributedCacheSpec
+import me.ahoo.test.asserts.assert
+import org.assertj.core.data.Offset
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.StringRedisTemplate
@@ -59,5 +63,29 @@ internal class RedisDistributedCachingTest : DistributedCacheSpec<String>() {
         if (null != lettuceConnectionFactory) {
             lettuceConnectionFactory.destroy()
         }
+    }
+
+    /**
+     * Redis 实现的 ttlAt 经 getExpire 重建，写读跨越秒边界时会有 ±1 秒漂移——
+     * 覆盖 TCK 的精确相等断言为容差断言（与 CodecExecutorSpec 的既有做法一致）。
+     */
+    @Test
+    override fun setWithTtl() {
+        val (key, value) = createCacheEntry()
+        cache[key].assert().isNull()
+        val cacheValue = DefaultCacheValue.ttlAt(value, 5)
+        cache.setCache(key, cacheValue)
+        cache[key].assert().isEqualTo(value)
+        cache.getTtlAt(key).assert().isCloseTo(cacheValue.ttlAt, Offset.offset(1))
+    }
+
+    @Test
+    override fun setWithTtlAmplitude() {
+        val (key, value) = createCacheEntry()
+        cache[key].assert().isNull()
+        val cacheValue = DefaultCacheValue.ttlAt(value, 5, 1)
+        cache.setCache(key, cacheValue)
+        cache[key].assert().isEqualTo(value)
+        cache.getTtlAt(key).assert().isCloseTo(cacheValue.ttlAt, Offset.offset(1))
     }
 }

--- a/cocache-test/src/main/kotlin/me/ahoo/cache/test/CacheSpec.kt
+++ b/cocache-test/src/main/kotlin/me/ahoo/cache/test/CacheSpec.kt
@@ -82,8 +82,11 @@ abstract class CacheSpec<K, V> {
         cache[key].assert().isEqualTo(value)
     }
 
+    /**
+     * open：Redis 等经 TTL 重建的实现可覆写为 ±1 秒容差断言（写读跨秒边界漂移），内存实现继承精确断言。
+     */
     @Test
-    fun setWithTtl() {
+    open fun setWithTtl() {
         val (key, value) = createCacheEntry()
         cache[key].assert().isNull()
         val cacheValue = DefaultCacheValue.ttlAt(value, 5)
@@ -93,7 +96,7 @@ abstract class CacheSpec<K, V> {
     }
 
     @Test
-    fun setWithTtlAmplitude() {
+    open fun setWithTtlAmplitude() {
         val (key, value) = createCacheEntry()
         cache[key].assert().isNull()
         val cacheValue = DefaultCacheValue.ttlAt(value, 5, 1)


### PR DESCRIPTION
main 上 Codecov 工作流失败：`RedisDistributedCachingTest.setWithTtlAmplitude` 期望 ...527 实际 ...528——写读跨秒边界时 Redis 经 getExpire 重建 ttlAt 的固有 ±1 秒漂移（同仓库 CodecExecutorSpec 早有容差断言与注释，此为漏网点）。\n\n修复：CacheSpec 的 setWithTtl/setWithTtlAmplitude 标记 open（内存实现继承精确断言），RedisDistributedCachingTest 覆写为 ±1 秒容差断言。\n\nTest Plan：本地 6 次连跑通过 + core/test 模块回归绿。