### PR TITLE
docs(wiki): regenerate llms.txt with 4.3.0 content

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -13,9 +13,10 @@
 - **Annotation-Driven**: @CoCache, @GuavaCache, @CaffeineCache, @JoinCacheable for declarative configuration
 - **Proxy-Based**: JDK dynamic proxies create cache implementations from annotated interfaces
 - **JoinCache**: Compose multiple cached values into a single JoinValue result
-- **Cache Stampede Prevention**: Per-key fine-grained locking with double-check pattern
+- **Cache Stampede Prevention**: Per-key striped locking (Guava Striped) with double-check pattern
 - **Cache Penetration Prevention**: MissingGuard sentinel values + optional BloomKeyFilter
 - **TTL Jitter**: Randomized TTL within amplitude bounds prevents cache avalanche
+- **Failure Degradation (v4.3.0)**: Redis read failures fall back to source (strict mode via `cocache.redis.strict-failure`); corrupted payloads self-heal; coherent caches close idempotently on shutdown
 
 ## Architecture
 
@@ -37,5 +38,5 @@ Modules:
 ./gradlew :cocache-core:test  # Module-specific tests
 ```
 
-- JDK 17+, Gradle 9.6.1, Kotlin 2.4.0
-- Group: `me.ahoo.cocache`, Version: `4.2.0`
+- JDK 17+, Gradle 9.7.0, Kotlin 2.4.10
+- Group: `me.ahoo.cocache`, Version: `4.3.0`

--- a/wiki/llms-full.txt
+++ b/wiki/llms-full.txt
@@ -1,7 +1,6 @@
 # CoCache
 > Level 2 Distributed Coherence Cache Framework for Java/Kotlin. Two-level caching (L2 local + L1 distributed) with event-driven coherence, annotation-based configuration, and proxy-based cache interfaces.
 ## Onboarding
-## Onboarding
 - [Contributor Guide](onboarding/contributor.md)
 - [Staff Engineer Guide](onboarding/staff-engineer.md)
 - [Executive Guide](onboarding/executive.md)
@@ -2871,12 +2870,13 @@ technical details.
 - [Introduction](guide/index.md)
 - [Quick Start](guide/quick-start.md)
 - [Configuration](guide/configuration.md)
+- [Changelog](guide/changelog.md)
 
 <doc title="Introduction" path="guide/index.md">
 
 # CoCache Introduction
 
-**CoCache** is a **Level 2 Distributed Coherence Cache Framework** for Java/Kotlin that provides a two-level caching architecture with event-driven coherence across distributed instances. It is published under the group `me.ahoo.cocache` at version **4.2.0**.
+**CoCache** is a **Level 2 Distributed Coherence Cache Framework** for Java/Kotlin that provides a two-level caching architecture with event-driven coherence across distributed instances. It is published under the group `me.ahoo.cocache` at version **4.3.0**.
 
 CoCache sits between your application and your data source, adding two cache layers -- a local in-memory L2 cache (Guava or Caffeine) and a shared distributed L1 cache (Redis) -- while keeping all instances coherent through an event bus.
 
@@ -3090,7 +3090,7 @@ autonumber
 | Property | Value | Source |
 |----------|-------|--------|
 | Group | `me.ahoo.cocache` | [gradle.properties:14](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L14) |
-| Version | `4.2.0` | [gradle.properties:15](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L15) |
+| Version | `4.3.0` | [gradle.properties:15](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L15) |
 | License | Apache License 2.0 | [gradle.properties:23](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L23) |
 | JDK | 17+ (via `jvmToolchain`) | [build.gradle.kts](https://github.com/Ahoo-Wang/CoCache/blob/main/build.gradle.kts) |
 | Gradle | 9.6.1 (wrapper) | [gradle/wrapper/gradle-wrapper.properties](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle/wrapper/gradle-wrapper.properties) |
@@ -3147,7 +3147,7 @@ This guide walks you through adding CoCache to a Spring Boot application, defini
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("me.ahoo.cocache:cocache-spring-boot-starter:4.2.0")
+    implementation("me.ahoo.cocache:cocache-spring-boot-starter:4.3.0")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 }
 ```
@@ -3156,7 +3156,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'me.ahoo.cocache:cocache-spring-boot-starter:4.2.0'
+    implementation 'me.ahoo.cocache:cocache-spring-boot-starter:4.3.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 ```
@@ -3167,7 +3167,7 @@ dependencies {
 <dependency>
     <groupId>me.ahoo.cocache</groupId>
     <artifactId>cocache-spring-boot-starter</artifactId>
-    <version>4.2.0</version>
+    <version>4.3.0</version>
 </dependency>
 <dependency>
     <groupId>org.springframework.boot</groupId>
@@ -3579,16 +3579,47 @@ Source: [cocache-example/.../cache/UserExtendInfoJoinCache.kt](https://github.co
 | Property | Type | Default | Description | Source |
 |----------|------|---------|-------------|--------|
 | `cocache.enabled` | `Boolean` | `true` | Enables or disables the entire CoCache auto-configuration | [CoCacheProperties.kt](https://github.com/Ahoo-Wang/CoCache/blob/main/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheProperties.kt) |
+| `cocache.redis.strict-failure` | `Boolean` | `false` | Redis failure policy: `false` = degrade (reads fall back to source, writes log warnings); `true` = rethrow `DataAccessException` (pre-4.3.0 behavior) | [CoCacheProperties.kt](https://github.com/Ahoo-Wang/CoCache/blob/main/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheProperties.kt) |
+| `cocache.redis.missing-guard-sentinel` | `String` | `"_nil_"` | Custom missing-guard sentinel value for Redis codecs (see notes below) | [CoCacheProperties.kt](https://github.com/Ahoo-Wang/CoCache/blob/main/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/CoCacheProperties.kt) |
 
 ```yaml
 # application.yml
 cocache:
   enabled: true
+  redis:
+    strict-failure: false
+    missing-guard-sentinel: "_nil_"
 ```
 
 When `cocache.enabled` is `false`, all CoCache beans are skipped. The conditional is handled by `@ConditionalOnCoCacheEnabled`.
 
 Source: [ConditionalOnCoCacheEnabled.kt](https://github.com/Ahoo-Wang/CoCache/blob/main/cocache-spring-boot-starter/src/main/kotlin/me/ahoo/cache/spring/boot/starter/ConditionalOnCoCacheEnabled.kt)
+
+#### Redis Failure Degradation (v4.3.0)
+
+Since v4.3.0, `RedisDistributedCache` degrades instead of propagating Redis failures to business callers:
+
+- **Read failures** → treated as a cache miss: the coherent cache falls back to the source (database), so business calls are unaffected during Redis outages or master-slave switchovers.
+- **Write / evict failures** → logged at `WARN` and swallowed — a cache write failure never blocks the business write path.
+- The eviction-event publish path (`RedisCacheEvictedEventBus`) degrades the same way (pub/sub is fire-and-forget by nature).
+
+Set `cocache.redis.strict-failure=true` to restore the strict pre-4.3.0 behavior (exceptions propagate). Note that during an outage with degradation enabled, every key not served by the local L2 cache falls back to the source once per client-side TTL window per process — plan source capacity accordingly. These properties apply only to auto-configured (fallback-created) caches; custom `DistributedCache` beans manage their own policy.
+
+#### Missing-Guard Sentinel (v4.3.0)
+
+Redis codecs mark negative-cache entries with the sentinel value `"_nil_"`. If your business data can legitimately equal the sentinel (an exact `"_nil_"` string, a single-element `{"_nil_"}` set, or a single-`"_nil_"`-keyed map written by an external writer), configure a custom sentinel:
+
+```yaml
+cocache:
+  redis:
+    missing-guard-sentinel: "\u0000myapp:nil"
+```
+
+Constraints:
+
+- Custom and default sentinels **do not recognize each other** — switching requires a simultaneous cluster-wide change (during a rolling upgrade, old instances would misread the new sentinel as a real value).
+- The value must not equal any legitimate serialized business value, and must not be blank (binding fails fast).
+- This affects only the Redis at-rest bytes written/read by the codecs; in-process missing-guard checks are unaffected.
 
 ## Auto-Configuration Bean Registry
 
@@ -3782,6 +3813,92 @@ Source: [CoCacheAutoConfiguration.kt:175-185](https://github.com/Ahoo-Wang/CoCac
 - [Quick Start Guide](./quick-start.md) -- Setup and first cache in minutes
 - [Testing Overview](../testing/index.md) -- TCK test specs and test patterns
 - [Performance Patterns](../testing/performance-patterns.md) -- TTL jitter and cache stampede details
+</doc>
+
+<doc title="Changelog" path="guide/changelog.md">
+
+# Changelog
+
+## v4.3.0 (Current)
+
+**Module Group:** `me.ahoo.cocache`
+
+### Highlights
+
+- **Cache Breakdown Protection Hardened** — Replaced the per-key lock map (which had a lock-object recycling race allowing duplicate source loads) with Guava `Striped` locks in `DefaultCoherentCache` (#519).
+- **Clock Thread Startup Race Fixed** — `CacheSecondClock` timer thread startup no longer races with field initialization; eliminates the "frozen clock → caches never expire" failure mode (#519).
+- **Stale Write-Back Race Fixed** — A per-key invalidation generation counter makes in-flight loads detect eviction events that arrive during loading: stale results are discarded (or compensating-evicted) instead of being pinned into both cache tiers until TTL (#519).
+- **Lifecycle Management** — `CoherentCache` now extends `AutoCloseable` with an idempotent `close()` (unregister from event bus + close distributed cache); Spring destroys caches automatically at shutdown (#519).
+- **Corrupted Payload Self-Healing** — Undecodable Redis values are deleted and treated as a cache miss (source reload) instead of throwing on every read (#520).
+- **Null Value Normalization** — `null` values are consistently written as negative-cache sentinels across all codecs (previously: empty-string corruption, NPEs, or codec-dependent semantics) (#520).
+- **Redis Failure Degradation** — By default, Redis read failures now degrade to cache-miss semantics (source reload, business calls unaffected) and write/evict failures only log a warning. Set `cocache.redis.strict-failure=true` to restore the strict throwing behavior (#520).
+- **Atomic Hash/Set Writes** — Structural codec writes use single-key Lua scripts (`DEL` + `HSET`/`SADD` + `EXPIRE`), eliminating concurrent-write field-union corruption. Empty Map/Set writes now silently evict the key instead of throwing (#520).
+- **Configurable Missing-Guard Sentinel** — New property `cocache.redis.missing-guard-sentinel` mitigates collisions between business data and the `"_nil_"` sentinel (#520).
+
+### Breaking Changes & Behavior Notes
+
+- **API removal (the only breaking change)**: `AbstractCodecExecutor.setPipelined`/`serialize` members were removed — affects only third-party codecs directly extending this abstract class.
+- `CodecExecutor.executeAndDecode` return type is now nullable (`CacheValue<V>?`) — covariant-compatible for implementers; direct callers must handle `null` on recompile.
+- Redis failures degrade by default (previously threw); JSON codec `null` values become negative-cache sentinels instead of `"null"`-literal round-trips.
+- Spring containers now auto-close caches at shutdown; `FactoryBean.getObject()` returns a memoized instance (eliminates duplicate event-bus subscriptions).
+- `strict-failure` / `missing-guard-sentinel` apply only to auto-configured (fallback-created) caches; custom `DistributedCache` beans are unaffected.
+- Wire formats (storage structure, eviction messages) are unchanged — rolling upgrades are fully compatible.
+
+### Dependencies
+
+| Dependency | Version |
+|------------|---------|
+| Spring Boot | 4.1.0 |
+| CosId | 3.2.0 |
+| Guava | 33.6.0-jre |
+| Kotlin | 2.4.10 |
+| JUnit | 6.1.3 |
+
+### Gradle Setup
+
+```kotlin
+implementation("me.ahoo.cocache:cocache-spring-boot-starter:4.3.0")
+```
+
+```xml
+<dependency>
+  <groupId>me.ahoo.cocache</groupId>
+  <artifactId>cocache-spring-boot-starter</artifactId>
+  <version>4.3.0</version>
+</dependency>
+```
+
+## v4.2.0
+
+**Module Group:** `me.ahoo.cocache`
+
+### Dependencies
+
+| Dependency | Version |
+|------------|---------|
+| Spring Boot | 4.1.0 |
+| CosId | 3.2.0 |
+| Guava | 33.6.0-jre |
+| Kotlin | 2.4.0 |
+| JUnit | 6.1.1 |
+
+### Gradle Setup
+
+```kotlin
+implementation("me.ahoo.cocache:cocache-spring-boot-starter:4.2.0")
+```
+
+```xml
+<dependency>
+  <groupId>me.ahoo.cocache</groupId>
+  <artifactId>cocache-spring-boot-starter</artifactId>
+  <version>4.2.0</version>
+</dependency>
+```
+
+## Historical Releases
+
+For the full release history, see [GitHub Releases](https://github.com/Ahoo-Wang/CoCache/releases).
 </doc>
 
 ## Architecture
@@ -4164,6 +4281,16 @@ autonumber
 |----------|-------|---------|
 | `FOREVER` | `-1` | Key exists but has no expiration |
 | `NOT_EXIST` | `-2` | Key does not exist in Redis |
+
+### Failure Degradation & Self-Healing (v4.3.0)
+
+Since v4.3.0, `RedisDistributedCache` absorbs Redis failures instead of propagating them:
+
+- **Read failures** (`DataAccessException`) degrade to a cache miss — `getCache` returns `null`, the coherent cache falls back to the source, and business calls continue to work through Redis outages.
+- **Write / evict failures** are logged at `WARN` and swallowed.
+- Set `cocache.redis.strict-failure=true` to restore strict exception propagation (see [Configuration](/guide/configuration#redis-failure-degradation-v4-3-0)).
+
+Additionally, the codec layer **self-heals corrupted payloads**: if a stored value cannot be decoded (external corruption, incompatible schema), the key is deleted and the read is treated as a cache miss so the next load repopulates a valid value — a broken key no longer throws on every read until TTL expiry.
 
 ## L0 -- CacheSource (Data Source)
 
@@ -4578,6 +4705,10 @@ flowchart LR
     style Unregister fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
 
 ```
+
+### Close Lifecycle (v4.3.0)
+
+Since v4.3.0, the lifecycle is closed-loop: `CoherentCache` extends `AutoCloseable` and `DefaultCoherentCache.close()` performs the `unregister` step idempotently (guarded by an atomic CAS — repeated calls are no-ops), then closes the distributed cache. In Spring applications, `CacheProxyFactoryBean`/`JoinCacheProxyFactoryBean` implement `DisposableBean`, so caches are unregistered and closed automatically at container shutdown. Manual (non-Spring) users should call `close()` when discarding a cache — previously, subscribers were registered on construction but never unregistered, leaking subscriptions for non-singleton cache lifecycles.
 
 ## Comparison of EventBus Implementations
 
@@ -9683,7 +9814,7 @@ Add the `cocache-test` module as a test dependency:
 ```kotlin
 // build.gradle.kts
 dependencies {
-    testImplementation("me.ahoo.cocache:cocache-test:4.2.0")
+    testImplementation("me.ahoo.cocache:cocache-test:4.3.0")
     testImplementation("me.ahoo.test:fluent-assert-core")
     testImplementation("io.mockk:mockk")
 }
@@ -11770,7 +11901,7 @@ The POM properties are sourced from [`gradle.properties`](https://github.com/Aho
 | Property | Value | Source |
 |----------|-------|--------|
 | `group` | `me.ahoo.cocache` | [`gradle.properties:14`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L14) |
-| `version` | `4.2.0` | [`gradle.properties:15`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L15) |
+| `version` | `4.3.0` | [`gradle.properties:15`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L15) |
 | `description` | `Level 2 Distributed Coherence Cache Framework` | [`gradle.properties:17`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L17) |
 | `website` | `https://github.com/Ahoo-Wang/CoCache` | [`gradle.properties:18`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L18) |
 | `license_name` | `The Apache Software License, Version 2.0` | [`gradle.properties:22`](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L22) |
@@ -11781,7 +11912,7 @@ The project version is defined centrally in [`gradle.properties`](https://github
 
 ```properties
 # [gradle.properties:15](https://github.com/Ahoo-Wang/CoCache/blob/main/gradle.properties#L15)
-version=4.2.0
+version=4.3.0
 ```
 
 All published artifacts share this version. To prepare a release:
@@ -12057,4 +12188,3 @@ Publish to this repository with:
 - [Modules](/modules/) -- Module architecture and responsibilities
 - [Architecture](/architecture/) -- System architecture overview
 </doc>
-

--- a/wiki/llms.txt
+++ b/wiki/llms.txt
@@ -13,13 +13,14 @@
 
 - [Introduction](guide/index.md) — Overview, key features, three-tier cache concept
 - [Quick Start](guide/quick-start.md) — Gradle/Maven setup, @EnableCoCache, Redis configuration
-- [Configuration](guide/configuration.md) — @CoCache parameters, @GuavaCache/@CaffeineCache, Spring Boot properties
+- [Configuration](guide/configuration.md) — @CoCache parameters, @GuavaCache/@CaffeineCache, Spring Boot properties, Redis failure degradation & missing-guard sentinel
+- [Changelog](guide/changelog.md) — Release history: v4.3.0 concurrency & reliability highlights, breaking changes, dependency tables
 
 ## Architecture
 
 - [Architecture Overview](architecture/index.md) — Module dependency graph, high-level system design
-- [Cache Layers](architecture/cache-layers.md) — L0/L1/L2 layer details, read/write/evict paths
-- [Coherence & Event Bus](architecture/coherence.md) — CacheEvictedEventBus, Redis Pub/Sub, cross-instance invalidation
+- [Cache Layers](architecture/cache-layers.md) — L0/L1/L2 layer details, read/write/evict paths, failure degradation & self-healing
+- [Coherence & Event Bus](architecture/coherence.md) — CacheEvictedEventBus, Redis Pub/Sub, cross-instance invalidation, close lifecycle
 - [Proxy & Annotations](architecture/proxy.md) — @CoCache proxy creation, EnableCoCacheRegistrar, JDK dynamic proxies
 
 ## API Reference


### PR DESCRIPTION
wiki 内容经 #522 大改后重新生成 LLM 索引：\n\n- `wiki/llms.txt`：新增 Changelog 条目，刷新 Configuration/Cache Layers/Coherence 描述（降级/自愈/哨兵/关闭生命周期）\n- `wiki/llms-full.txt`：全量重建 31 个 doc 块（含新增 changelog 页），553KB\n- 根 `llms.txt`：版本 4.3.0、Kotlin 2.4.10/Gradle 9.7、Striped 锁措辞、新增 Failure Degradation 概念条目\n\n验证：31 页全部存在、无空 doc 块、索引链接与文件一一对应、wiki build 通过。