### PR TITLE
docs(skills): document CacheSource null-return missing-guard semantics

### DIFF
--- a/skills/cocache/SKILL.md
+++ b/skills/cocache/SKILL.md
@@ -50,7 +50,7 @@ Use caches through Kotlin operators: `cache[key]`, `cache[key] = value`, `cache.
 CoCache auto-configures defaults, but each component can be overridden:
 - Per cache, define named beans such as `UserCache.CacheSource`, `UserCache.ClientSideCache`, `UserCache.KeyConverter`, or `UserCache.JoinKeyExtractor`.
 - Globally, define beans by type; auto-configured beans use `@ConditionalOnMissingBean`.
-- For data loading, implement `CacheSource<K, V>.loadCacheValue(key)` and return `DefaultCacheValue.forever(value)`, `DefaultCacheValue.ttlAt(value, ttl)`, or bounded `DefaultCacheValue.missingGuard(ttl, amplitude)` values.
+- For data loading, implement `CacheSource<K, V>.loadCacheValue(key)` and return `DefaultCacheValue.forever(value)`, `DefaultCacheValue.ttlAt(value, ttl)`, or bounded `DefaultCacheValue.missingGuard(ttl, amplitude)` values. Returning `null` for a missing key is also valid — CoCache auto-caches a missing guard with the cache's TTL (cache-penetration protection).
 
 ## Testing Pattern
 

--- a/skills/cocache/references/custom-implementation.md
+++ b/skills/cocache/references/custom-implementation.md
@@ -319,6 +319,19 @@ interface CacheSource<K, V> {
 }
 ```
 
+### Return-value semantics
+
+What `loadCacheValue` returns decides how CoCache caches the outcome:
+
+| Returns | CoCache behavior |
+|---------|------------------|
+| `DefaultCacheValue.ttlAt(value, ttl)` / `forever(value)` | Positive entry, cached at both levels |
+| `null` | CoCache automatically caches a missing guard using the cache's `ttl`/`ttlAmplitude` (`@CoCache` defaults) — cache-penetration protection. Callers still see `null` from `get(key)` |
+| `DefaultCacheValue.missingGuard(ttl, amplitude)` | Negative entry with a custom window — use it when the cache default is too long (e.g. transient source failures) or too short |
+| throws | Nothing is cached; the exception propagates to the caller of `get(key)` |
+
+Returning `null` for "key does not exist" is the idiomatic baseline — the framework performs the negative caching for you. Return an explicit `missingGuard(ttl)` only to override that window.
+
 ### Implementation Patterns
 
 ```kotlin


### PR DESCRIPTION
## Summary

Documents the return-value semantics of `CacheSource.loadCacheValue` in the `cocache` skill — closing a documentation gap found by the iteration-2 skill evaluation, where **both** the skill-informed and the baseline answers incorrectly claimed that returning `null` caches nothing (the framework in fact auto-caches a missing guard).

## Changes

- `skills/cocache/references/custom-implementation.md`: new "Return-value semantics" table under Custom CacheSource:
  - `ttlAt(value, ttl)` / `forever(value)` → positive entry
  - `null` → CoCache automatically caches a missing guard using the cache's `ttl`/`ttlAmplitude` (cache-penetration protection); callers still see `null` from `get(key)`
  - `missingGuard(ttl, amplitude)` → negative entry with a custom window (use when the cache default is too long/short)
  - throws → nothing is cached; the exception propagates to the caller of `get(key)`
- `skills/cocache/SKILL.md`: one-clause addition to Extension Points stating the same `null` semantics.

Behavior verified against source: `DefaultCoherentCache.kt:151` (auto missing-guard on null return, using the cache's configured ttl) and `ComputedCache.kt:29-35` (`get()` returns null for guarded entries — callers never see the sentinel value).

## Testing

- Skill eval `eval-1 cache-source-conventions` re-run with the updated skill: **6/6 assertions pass** (was 4/6 — the two failing assertions, null-return semantics and its anti-assertion, now pass). Context: the iteration-2 benchmark measured with_skill 22/24 vs without_skill 7/24, and this was the only assertion pair both configurations failed.
- `./gradlew check` passes (docs-only change; no Gradle module consumes `skills/`).
