### PR TITLE
docs(skills): fix review findings and cover v4.3.0 failure-policy surface

### DIFF
--- a/skills/cocache/SKILL.md
+++ b/skills/cocache/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cocache
-description: Use when building or modifying Java/Kotlin applications with CoCache two-level distributed coherent caching. Invoke for @CoCache cache interfaces, @JoinCacheable composition, Redis-backed coherence, Spring Boot integration, cache proxy behavior, custom cache backends, cache breakdown protection, or CoCache TCK tests.
+description: Use when building or modifying Java/Kotlin applications with CoCache two-level distributed coherent caching. Invoke for @CoCache cache interfaces, @JoinCacheable composition, Redis-backed coherence, Spring Boot integration, cache proxy behavior, custom cache backends, cache penetration/breakdown protection (missing guards), Redis failure policy (strict-failure, missing-guard sentinel), Redis TTL-drift test failures, or CoCache TCK tests.
 ---
 
 # CoCache Development Guide
@@ -16,7 +16,7 @@ Choose the smallest reference that fits the request:
 
 | Task | Read |
 |------|------|
-| Add CoCache to a Spring or Spring Boot app | `references/setup.md` |
+| Add CoCache to a Spring or Spring Boot app; configure Redis failure behavior or the missing-guard sentinel | `references/setup.md` |
 | Compose cached values with `@JoinCacheable` | `references/join-cache.md` |
 | Write or update tests | `references/testing.md` |
 | Implement a custom L1/L2 cache, event bus, key converter, or source | `references/custom-implementation.md` |

--- a/skills/cocache/SKILL.md
+++ b/skills/cocache/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cocache
-description: Use when building or modifying Java/Kotlin applications with CoCache two-level distributed coherent caching. Invoke for @CoCache cache interfaces, @JoinCacheable composition, Redis-backed coherence, Spring Boot integration, cache proxy behavior, custom cache backends, cache penetration/breakdown protection (missing guards), Redis failure policy (strict-failure, missing-guard sentinel), Redis TTL-drift test failures, or CoCache TCK tests.
+description: Use when building or modifying Java/Kotlin applications with CoCache two-level distributed coherent caching. Invoke for @CoCache cache interfaces, @JoinCacheable composition, Redis-backed coherence, Spring Boot integration, cache proxy behavior, custom cache backends, cache penetration protection (missing guards), cache breakdown protection, Redis failure policy (strict-failure, missing-guard sentinel), Redis TTL-drift test failures, or CoCache TCK tests.
 ---
 
 # CoCache Development Guide

--- a/skills/cocache/references/join-cache.md
+++ b/skills/cocache/references/join-cache.md
@@ -40,7 +40,7 @@ get(key)
 1. `evict(key)`: Gets primary value, extracts join key, evicts both caches
 2. `evict(firstKey, joinKey)`: Directly evicts both by their respective keys
 
-**TTL:** The composed `JoinValue` uses `min(firstTtl, secondTtl)`.
+**TTL:** The composed `JoinValue` expires at the earlier of the two entries' absolute deadlines (`min(firstTtlAt, secondTtlAt)`). If the secondary value is missing or already expired, the primary entry's deadline is used.
 
 ## Creating a JoinCache
 

--- a/skills/cocache/references/setup.md
+++ b/skills/cocache/references/setup.md
@@ -6,6 +6,7 @@
 - [Module Selection](#module-selection)
 - [Minimal Configuration](#minimal-configuration)
 - [Step-by-Step Setup](#step-by-step-setup)
+- [Redis Failure Behavior](#redis-failure-behavior)
 - [Without Spring Boot](#without-spring-boot)
 - [Single-Instance Setup (No Redis)](#single-instance-setup-no-redis)
 - [Spring Cache Bridge](#spring-cache-bridge)
@@ -119,10 +120,10 @@ That's it. CoCache auto-configures:
 ```kotlin
 // build.gradle.kts
 plugins {
-    id("org.springframework.boot") version "4.0.5"
+    id("org.springframework.boot") version "4.1.0"
     id("io.spring.dependency-management") version "1.1.7"
-    kotlin("jvm") version "2.3.20"
-    kotlin("plugin.spring") version "2.3.20"
+    kotlin("jvm") version "2.4.10"
+    kotlin("plugin.spring") version "2.4.10"
 }
 
 dependencies {
@@ -203,6 +204,37 @@ class UserService(
     }
 }
 ```
+
+## Redis Failure Behavior
+
+`RedisDistributedCache` catches only `DataAccessException` (never broader types) and degrades by default:
+
+- **Read failure** → returns `null` (cache miss), so the coherent cache reloads from the `CacheSource`.
+- **Write/evict failure** → logged as WARN and swallowed.
+
+Set `cocache.redis.strict-failure: true` to rethrow the exception instead of degrading:
+
+```yaml
+cocache:
+  redis:
+    strict-failure: true
+```
+
+This property reaches only the caches the auto-configuration creates. If you define your own `DistributedCache` bean, you own its failure policy.
+
+Corrupted payloads self-heal: when the codec cannot decode a stored value, CoCache deletes the key and treats the read as a miss, so the next `get` reloads from the source instead of failing repeatedly on the same bad bytes.
+
+### Custom Missing-Guard Sentinel
+
+Negative cache entries are stored in Redis under a sentinel value (default `"_nil_"`). If that string can collide with a legitimate serialized payload, override it:
+
+```yaml
+cocache:
+  redis:
+    missing-guard-sentinel: "__my_missing__"
+```
+
+The default and a custom sentinel do not recognize each other — a custom value must be switched across the whole cluster at once (old instances would read the new sentinel as a real value during a rolling upgrade), must not be blank, and must never equal any legitimate payload.
 
 ## Without Spring Boot
 
@@ -301,7 +333,9 @@ When Spring Actuator is on the classpath:
 | `/actuator/cocache/{name}` | GET | Cache stats |
 | `/actuator/cocache/{name}/{key}` | GET | Get a cache entry |
 | `/actuator/cocache/{name}/{key}` | DELETE | Evict a cache entry |
-| `/actuator/cocacheClient` | GET | Client-side cache info |
+| `/actuator/cocacheClient/{name}` | GET | Client-side cache size |
+| `/actuator/cocacheClient/{name}/{key}` | GET | Get a client-side cache entry |
+| `/actuator/cocacheClient/{name}` | DELETE | Clear a client-side cache |
 
 ## Disabling CoCache
 

--- a/skills/cocache/references/setup.md
+++ b/skills/cocache/references/setup.md
@@ -209,7 +209,7 @@ class UserService(
 
 `RedisDistributedCache` catches only `DataAccessException` (never broader types) and degrades by default:
 
-- **Read failure** → returns `null` (cache miss), so the coherent cache reloads from the `CacheSource`.
+- **Read failure** → logged as WARN, then returns `null` (cache miss), so the coherent cache reloads from the `CacheSource`.
 - **Write/evict failure** → logged as WARN and swallowed.
 
 Set `cocache.redis.strict-failure: true` to rethrow the exception instead of degrading:

--- a/skills/cocache/references/testing.md
+++ b/skills/cocache/references/testing.md
@@ -9,6 +9,7 @@
 - [Testing CacheEvictedEventBus](#testing-cacheevictedeventbus)
 - [Testing Cross-Instance Coherence](#testing-cross-instance-coherence)
 - [Testing with Redis (Integration Tests)](#testing-with-redis-integration-tests)
+- [Redis-Style TTL Drift](#redis-style-ttl-drift)
 - [Assertion Style](#assertion-style)
 - [Writing Custom Test Cases](#writing-custom-test-cases)
 - [Test Dependencies](#test-dependencies)
@@ -25,6 +26,8 @@ CoCache provides abstract test specs in `cocache-test` that verify cache contrac
 | `DefaultCoherentCacheSpec<K,V>` | all of CacheSpec + cache source, event bus, concurrency | Two-level cache implementations |
 | `MultipleInstanceSyncSpec<K,V>` | cross-instance coherence | Event bus implementations |
 | `CacheEvictedEventBusSpec` | publish, register, unregister | Event bus implementations |
+
+All specs live in package `me.ahoo.cache.test`, except `CacheEvictedEventBusSpec` which is in `me.ahoo.cache.test.consistency`.
 
 ## Testing a ClientSideCache Implementation
 
@@ -118,7 +121,7 @@ This tests:
 ```kotlin
 import me.ahoo.cache.consistency.CacheEvictedEventBus
 import me.ahoo.cache.consistency.GuavaCacheEvictedEventBus
-import me.ahoo.cache.test.CacheEvictedEventBusSpec
+import me.ahoo.cache.test.consistency.CacheEvictedEventBusSpec
 
 class MyEventBusTest : CacheEvictedEventBusSpec() {
 
@@ -214,6 +217,27 @@ class RedisDistributedCacheTest : DistributedCacheSpec<String>() {
     }
 }
 ```
+
+## Redis-Style TTL Drift
+
+Caches that reconstruct `ttlAt` from the store's remaining expiry (e.g. `RedisDistributedCache` reads Redis `getExpire`) can drift by ±1 second when the write and the read land on different sides of a second boundary. `CacheSpec.setWithTtl` and `CacheSpec.setWithTtlAmplitude` are `open` for exactly this reason — override them to relax the exact `ttlAt` equality into a tolerance assertion. In-memory implementations inherit the exact assertions unchanged.
+
+```kotlin
+@Test
+override fun setWithTtl() {
+    val (key, value) = createCacheEntry()
+    cache[key].assert().isNull()
+    val cacheValue = DefaultCacheValue.ttlAt(value, 5)
+    cache.setCache(key, cacheValue)
+    cache[key].assert().isEqualTo(value)
+    cache.getTtlAt(key).assert().isCloseTo(cacheValue.ttlAt, Offset.offset(1))
+}
+```
+
+Two details matter here:
+
+- The `@Test` annotation must be repeated on the override — JUnit 5 does not inherit it from the overridden spec method.
+- `Offset` comes from `org.assertj.core.data.Offset`. Passing it as an assertion argument is the one allowed AssertJ import; `assertThat()` itself stays banned.
 
 ## Assertion Style
 


### PR DESCRIPTION
## 背景

对 `skills/` 进行了一轮审查（skill-creator 流程），将技能文档中的 20 项事实性声明与 v4.3.0 实际代码逐条核对。16 项准确，本 PR 修复发现的偏差并补齐 v4.3.0 用户可见特性的覆盖。

## 修复内容

**正确性修复**
- **testing.md**: `CacheEvictedEventBusSpec` 的 import 修正为 `me.ahoo.cache.test.consistency`（原写法复制即编译错误），并在 spec 总览处加注包名差异
- **setup.md**: 示例版本 Spring Boot 4.0.5 → 4.1.0、Kotlin 2.3.20 → 2.4.10，对齐 `libs.versions.toml` 的仓库基线
- **setup.md**: actuator 表格修正 —— `cocacheClient` 端点所有操作都需要 `@Selector`，无裸 `GET /actuator/cocacheClient`；补齐 size/entry/clear 三个真实路径（`CoCacheClientEndpoint.kt`）
- **join-cache.md**: 组合 TTL 表述精确化 —— 取两个条目 ttlAt 绝对期限的较小者，secondary 缺失/过期时回落 primary 期限（`SimpleJoinCache.kt:66-74`）

**新增覆盖（v4.3.0 用户可见特性，iteration-3 候选素材）**
- **setup.md** 新增 `Redis Failure Behavior` 一节：仅捕获 `DataAccessException` 的默认降级语义（读失败按 miss 回源、写/evict 失败 WARN 吞没）、`cocache.redis.strict-failure` 开关（仅作用于自动配置创建的缓存）、codec 损坏自愈（解码失败删 key 按 miss 处理）、`cocache.redis.missing-guard-sentinel` 自定义哨兵的全集群切换约束
- **testing.md** 新增 `Redis-Style TTL Drift` 一节：`CacheSpec.setWithTtl`/`setWithTtlAmplitude` 为 Redis 风格实现预留的 open 覆写点（±1s 容差），含 `@Test` 需重复标注、`Offset` 是唯一允许的 AssertJ import 两个易错细节

**触发面**
- **SKILL.md** description 补充触发词（missing guards、strict-failure、missing-guard sentinel、TTL-drift test failures），路由表 setup.md 一行同步扩展

## 验证

- 全部修改均先核对源码（`AbstractCodecExecutor.kt`、`RedisDistributedCache.kt`、`CoCacheProperties.kt`、`CoCacheClientEndpoint.kt`、`CacheSpec.kt`、`RedisDistributedCachingTest.kt`、`SimpleJoinCache.kt`、`libs.versions.toml`）
- 纯 Markdown 文档变更（`skills/` 不被任何 Gradle 任务消费），未跑 `./gradlew check`
- 评测工作区（gitignored）中 eval-3 的 TTL 断言措辞已本地同步为新表述