### PR TITLE
docs(skills): clarify missing-guard sentinel scope is Redis at-rest bytes only

### DIFF
--- a/skills/cocache/references/setup.md
+++ b/skills/cocache/references/setup.md
@@ -234,7 +234,7 @@ cocache:
     missing-guard-sentinel: "__my_missing__"
 ```
 
-The default and a custom sentinel do not recognize each other — a custom value must be switched across the whole cluster at once (old instances would read the new sentinel as a real value during a rolling upgrade), must not be blank, and must never equal any legitimate payload.
+The default and a custom sentinel do not recognize each other — a custom value must be switched across the whole cluster at once (old instances would read the new sentinel as a real value during a rolling upgrade), must not be blank, and must never equal any legitimate payload. The sentinel only governs the bytes written to and recognized from Redis; in-process layers always treat the `"_nil_"` shape as a missing guard regardless of this setting.
 
 ## Without Spring Boot
 


### PR DESCRIPTION
## 背景

PR #528 的代码审查给出的非阻塞建议（详见审查报告 Minor/Recommendations 部分）：
sentinel 小节可补一句作用域说明。本轮 iteration-3 评测将其转正——eval-2 新增
a5 断言（"sentinel 仅作用于 Redis 静止字节；进程内各层始终按 `"_nil_"` 形状判定"
）需要这句作为出处，实现评测断言与技能文档的闭环。

## 变更

`skills/cocache/references/setup.md` Custom Missing-Guard Sentinel 小节补一句：

> The sentinel only governs the bytes written to and recognized from Redis; in-process layers always treat the `"_nil_"` shape as a missing guard regardless of this setting.

依据 `AbstractCodecExecutor` 的 `missingGuardSentinel` 参数 KDoc
（限定范围：仅影响 Redis 静止字节的写入与读侧识别；进程内 `isMissingGuard` core
常量判定不受影响）。

## 验证

- 纯单句文档补充，无行为变更；`skills/` 不被任何 Gradle 任务消费
- iteration-3 eval-2 with_skill 5/5（含新 a5），评测工作区见 `skills/cocache-workspace/iteration-3/`（gitignored）